### PR TITLE
Bounded GraphQL server cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "prettier --check --plugin-search-dir=. .",
     "lint:fix": "pnpm lint:fix:prettier",
     "lint:fix:prettier": "prettier --write --plugin-search-dir=. .",
-    "play": "npm -C playground dev",
+    "play": "cd playground && pnpm dev",
     "play:build": "pnpm build && cd playground && pnpm build",
     "prepublish:ci": "pnpm -r update",
     "publish:ci": "esmo scripts/publish.ts",

--- a/packages/flatbread/package.json
+++ b/packages/flatbread/package.json
@@ -34,6 +34,7 @@
     "*.d.ts"
   ],
   "dependencies": {
+    "@apollo/utils.keyvaluecache": "^1.0.1",
     "@flatbread/config": "workspace:*",
     "@flatbread/core": "workspace:*",
     "@flatbread/source-filesystem": "workspace:*",

--- a/packages/flatbread/src/cli/index.ts
+++ b/packages/flatbread/src/cli/index.ts
@@ -39,7 +39,7 @@ prog
   .command('start [corunner]', 'Start flatbread with a GraphQL server')
   .option('--, _', 'Pass options to the corunning script')
   .option('-p, --port', 'Port to run the GraphQL server', 5057)
-  .option('-H, --https', 'Use self-signed HTTPS certificate', true)
+  .option('-H, --https', 'Use self-signed HTTPS certificate', false)
   .option('-o, --open', 'Open the explorer in a browser tab', false)
   .option(
     '-X, --exec',

--- a/packages/flatbread/src/graphql/server.ts
+++ b/packages/flatbread/src/graphql/server.ts
@@ -25,7 +25,7 @@ async function startApolloServer(schema: GraphQLSchema, { port = 5050 } = {}) {
       maxSize: Math.pow(2, 20) * 100,
     }),
     plugins: [
-      // Apollo Server will drain your HTTP server when you call the stop() method (which is also called for you when the SIGTERM and SIGINT signals are received
+      // Apollo Server will drain your HTTP server when you call the stop() method (which is also called for you when the SIGTERM and SIGINT signals are received)
       // @see https://www.apollographql.com/docs/apollo-server/api/plugin/drain-http-server/
       ApolloServerPluginDrainHttpServer({ httpServer }),
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,7 @@ importers:
 
   packages/flatbread:
     specifiers:
+      '@apollo/utils.keyvaluecache': ^1.0.1
       '@flatbread/config': workspace:*
       '@flatbread/core': workspace:*
       '@flatbread/source-filesystem': workspace:*
@@ -119,6 +120,7 @@ importers:
       typescript: ^4.7.4
       vfile: ^5.3.4
     dependencies:
+      '@apollo/utils.keyvaluecache': 1.0.1
       '@flatbread/config': link:../config
       '@flatbread/core': link:../core
       '@flatbread/source-filesystem': link:../source-filesystem


### PR DESCRIPTION
## Changes
Introduces an LRU cache with a ~100MiB max size to the Apollo GraphQL server running in Express. This prevents the cache from growing to an unbounded size which can lead to an OOM error and crash the running process.

### Misc
- Changes the CLI to default to HTTP
  - Apollo Studio (the web query builder) launches in HTTP, so the provided CLI feedback when set to HTTPS will give a clickable link which errors out when opened until you delete the 's' from the address. So this is more of a DX change since HTTP should be fine for local means
- Fixes the monorepo script for opening the playground in `dev` from the root

