### PR TITLE
Run the pipeline on external PRs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,7 @@ name: Pipeline
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
This should hopefully expose the pipeline in a safe context to forks with a merge target pointed to the main Flatbread repo.