### PR TITLE
feat: support Cursor SDK model params in proof

### DIFF
--- a/.cursor/skills/proof/SKILL.md
+++ b/.cursor/skills/proof/SKILL.md
@@ -29,9 +29,15 @@ You (the parent agent) author the DAG inline using your understanding of the use
 {
   "title": "<short human-readable title for the run>",
   "models": {
-    "HIGH": "gpt-5.3-codex",
+    "HIGH": {
+      "id": "claude-opus-4-7",
+      "params": [{ "id": "effort", "value": "max" }]
+    },
     "MED": "composer-2",
-    "LOW": "auto-low"
+    "LOW": {
+      "id": "gpt-5.4-nano",
+      "params": [{ "id": "reasoning", "value": "low" }]
+    }
   },
   "tasks": [
     {
@@ -49,7 +55,7 @@ Rules:
 - Every `depends_on` entry must reference another task's `id`.
 - No cycles. The runner rejects cyclic DAGs at parse time.
 - `complexity` controls the model the subagent uses (see table below). Pick `HIGH` for novel/complex reasoning, `MED` for typical implementation, `LOW` for mechanical/lookup tasks.
-- Optional top-level `models` can override the default complexity → model map for this DAG.
+- Optional top-level `models` can override the default complexity → model map for this DAG. Values can be either a plain SDK model id string or `{ "id": "...", "params": [{ "id": "...", "value": "..." }] }`.
 - `subtask_prompt` should read like a standalone request — the runner automatically prepends a short summary of upstream task outputs, so you do not need to repeat them.
 - Do **not** put two tasks that write to the same file in the same rank (siblings within a rank run concurrently and would race).
 
@@ -167,7 +173,7 @@ After the runner exits, briefly summarize what completed/failed and re-link the 
 | MED        | `composer-2`      |
 | LOW        | `gpt-5.4-nano`    |
 
-Override any subset inline with top-level DAG `models`, or pass a reusable profile with `--models-file <path>`. Precedence is defaults < DAG `models` < `--models-file`. The Cursor model catalog can vary by account.
+Override any subset inline with top-level DAG `models`, or pass a reusable profile with `--models-file <path>`. Values can be plain SDK model id strings or SDK model selections with `params`. At run time, Proof calls `Cursor.models.list()`, validates ids and param values, and expands partial selections to the closest valid preset variant using the model's default variant for omitted params. Precedence is defaults < DAG `models` < `--models-file`. The Cursor model catalog can vary by account.
 
 ### Discovering valid model ids
 

--- a/.cursor/skills/proof/SKILL.md
+++ b/.cursor/skills/proof/SKILL.md
@@ -33,7 +33,7 @@ You (the parent agent) author the DAG inline using your understanding of the use
       "id": "claude-opus-4-7",
       "params": [{ "id": "effort", "value": "max" }]
     },
-    "MED": "composer-2",
+    "MED": { "id": "composer-2" },
     "LOW": {
       "id": "gpt-5.4-nano",
       "params": [{ "id": "reasoning", "value": "low" }]
@@ -55,7 +55,7 @@ Rules:
 - Every `depends_on` entry must reference another task's `id`.
 - No cycles. The runner rejects cyclic DAGs at parse time.
 - `complexity` controls the model the subagent uses (see table below). Pick `HIGH` for novel/complex reasoning, `MED` for typical implementation, `LOW` for mechanical/lookup tasks.
-- Optional top-level `models` can override the default complexity → model map for this DAG. Values can be either a plain SDK model id string or `{ "id": "...", "params": [{ "id": "...", "value": "..." }] }`.
+- Optional top-level `models` can override the default complexity → model map for this DAG. Values must be model selection objects of the shape `{ "id": "...", "params": [{ "id": "...", "value": "..." }] }`, with `params` omitted when unused.
 - `subtask_prompt` should read like a standalone request — the runner automatically prepends a short summary of upstream task outputs, so you do not need to repeat them.
 - Do **not** put two tasks that write to the same file in the same rank (siblings within a rank run concurrently and would race).
 

--- a/.cursor/skills/proof/SKILL.md
+++ b/.cursor/skills/proof/SKILL.md
@@ -30,10 +30,10 @@ You (the parent agent) author the DAG inline using your understanding of the use
   "title": "<short human-readable title for the run>",
   "models": {
     "HIGH": {
-      "id": "claude-opus-4-7",
-      "params": [{ "id": "effort", "value": "max" }]
+      "id": "gpt-5.4",
+      "params": [{ "id": "reasoning", "value": "high" }]
     },
-    "MED": { "id": "composer-2" },
+    "MED": "composer-2",
     "LOW": {
       "id": "gpt-5.4-nano",
       "params": [{ "id": "reasoning", "value": "low" }]
@@ -55,7 +55,7 @@ Rules:
 - Every `depends_on` entry must reference another task's `id`.
 - No cycles. The runner rejects cyclic DAGs at parse time.
 - `complexity` controls the model the subagent uses (see table below). Pick `HIGH` for novel/complex reasoning, `MED` for typical implementation, `LOW` for mechanical/lookup tasks.
-- Optional top-level `models` can override the default complexity → model map for this DAG. Values must be model selection objects of the shape `{ "id": "...", "params": [{ "id": "...", "value": "..." }] }`, with `params` omitted when unused.
+- Optional top-level `models` can override the default complexity → model map for this DAG. Values can be plain SDK model id strings or model selection objects of the shape `{ "id": "...", "params": [{ "id": "...", "value": "..." }] }`, with `params` omitted when unused.
 - `subtask_prompt` should read like a standalone request — the runner automatically prepends a short summary of upstream task outputs, so you do not need to repeat them.
 - Do **not** put two tasks that write to the same file in the same rank (siblings within a rank run concurrently and would race).
 
@@ -175,9 +175,22 @@ After the runner exits, briefly summarize what completed/failed and re-link the 
 
 Override any subset inline with top-level DAG `models`, or pass a reusable profile with `--models-file <path>`. Values can be plain SDK model id strings or SDK model selections with `params`. At run time, Proof calls `Cursor.models.list()`, validates ids and param values, and expands partial selections to the closest valid preset variant using the model's default variant for omitted params. Precedence is defaults < DAG `models` < `--models-file`. The Cursor model catalog can vary by account.
 
+To use a cheaper high-capability GPT model, use the base SDK id plus params, not a suffix-style id:
+
+```json
+{
+  "models": {
+    "HIGH": {
+      "id": "gpt-5.4",
+      "params": [{ "id": "reasoning", "value": "high" }]
+    }
+  }
+}
+```
+
 ### Discovering valid model ids
 
-Many Cursor CLI catalog models encode reasoning effort and Max Mode as **slug suffixes** (e.g. `claude-opus-4-7-thinking-max`, `gpt-5.5-extra-high`, `gpt-5.3-codex-xhigh`), but the Cursor SDK may accept only base slugs. Do not compose SDK model ids from CLI suffixes by hand. For SDK-bound code, prefer `Cursor.models.list()` or the SDK's `ConfigurationError` catalog over `cursor-agent --list-models`.
+Many Cursor CLI catalog models encode reasoning effort and Max Mode as **slug suffixes** (e.g. `claude-opus-4-7-thinking-max`, `gpt-5.5-extra-high`, `gpt-5.3-codex-xhigh`), but the Cursor SDK may accept only base slugs plus `params`. Do not compose SDK model ids from CLI suffixes by hand: use `{ "id": "gpt-5.4", "params": [{ "id": "reasoning", "value": "high" }] }`, not `gpt-5.4-high`. For SDK-bound code, prefer `Cursor.models.list()` or the SDK's `ConfigurationError` catalog over `cursor-agent --list-models`.
 
 Ways to enumerate model ids:
 

--- a/.cursor/skills/proof/examples/dag-flatbread-flow-pmf-audit.json
+++ b/.cursor/skills/proof/examples/dag-flatbread-flow-pmf-audit.json
@@ -2,9 +2,9 @@
   "title": "Flatbread Flow PMF Audit (no sub-sub-agents)",
   "framing": "Treat Flatbread as Git-native relational content for TypeScript apps, backed by flat files. GraphQL is one interface, not the whole product identity.",
   "models": {
-    "HIGH": "claude-opus-4-7",
-    "MED": "gpt-5.5",
-    "LOW": "gpt-5.4-mini"
+    "HIGH": { "id": "claude-opus-4-7" },
+    "MED": { "id": "gpt-5.5" },
+    "LOW": { "id": "gpt-5.4-mini" }
   },
   "tasks": [
     {

--- a/.cursor/skills/proof/examples/flatbread/dag-codegen-change.json
+++ b/.cursor/skills/proof/examples/flatbread/dag-codegen-change.json
@@ -2,9 +2,9 @@
   "title": "Flatbread codegen-only change (no sub-sub-agents)",
   "framing": "Treat Flatbread as Git-native relational content for TypeScript apps, backed by flat files. GraphQL is one interface, not the whole product identity.",
   "models": {
-    "HIGH": "claude-opus-4-7",
-    "MED": "gpt-5.5",
-    "LOW": "gpt-5.4-mini"
+    "HIGH": { "id": "claude-opus-4-7" },
+    "MED": { "id": "gpt-5.5" },
+    "LOW": { "id": "gpt-5.4-mini" }
   },
   "tasks": [
     {

--- a/.cursor/skills/proof/examples/flatbread/dag-docs-sync.json
+++ b/.cursor/skills/proof/examples/flatbread/dag-docs-sync.json
@@ -2,9 +2,9 @@
   "title": "Flatbread docs / README sync (no sub-sub-agents)",
   "framing": "Treat Flatbread as Git-native relational content for TypeScript apps, backed by flat files. GraphQL is one interface, not the whole product identity.",
   "models": {
-    "HIGH": "claude-opus-4-7",
-    "MED": "gpt-5.5",
-    "LOW": "gpt-5.4-mini"
+    "HIGH": { "id": "claude-opus-4-7" },
+    "MED": { "id": "gpt-5.5" },
+    "LOW": { "id": "gpt-5.4-mini" }
   },
   "tasks": [
     {

--- a/.cursor/skills/proof/examples/flatbread/dag-schema-migration.json
+++ b/.cursor/skills/proof/examples/flatbread/dag-schema-migration.json
@@ -2,9 +2,9 @@
   "title": "Flatbread schema-breaking migration (no sub-sub-agents; pause at human checkpoint after contract-synth)",
   "framing": "Treat Flatbread as Git-native relational content for TypeScript apps, backed by flat files. GraphQL is one interface, not the whole product identity.",
   "models": {
-    "HIGH": "claude-opus-4-7",
-    "MED": "gpt-5.5",
-    "LOW": "gpt-5.4-mini"
+    "HIGH": { "id": "claude-opus-4-7" },
+    "MED": { "id": "gpt-5.5" },
+    "LOW": { "id": "gpt-5.4-mini" }
   },
   "tasks": [
     {

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -68,8 +68,8 @@ Every DAG has a `title` and a `tasks` array. Each task needs:
 
 Proof computes ranks with Kahn topological sort and runs sibling tasks in the same rank concurrently. Avoid placing two sibling tasks in the same rank if they write the same files.
 
-Optional top-level `models` can override the default complexity map with either
-plain SDK model ids or SDK model selections:
+Optional top-level `models` can override the default complexity map with SDK
+model selections:
 
 ```json
 {
@@ -81,7 +81,7 @@ plain SDK model ids or SDK model selections:
         { "id": "effort", "value": "max" }
       ]
     },
-    "MED": "composer-2",
+    "MED": { "id": "composer-2" },
     "LOW": {
       "id": "gpt-5.4-nano",
       "params": [{ "id": "reasoning", "value": "low" }]
@@ -146,7 +146,6 @@ Proof also exposes helpers for tooling:
 import {
   computeRanks,
   createModelSelectionResolver,
-  createModelResolver,
   parseDAG,
   resolveModelSelectionFromCatalog,
   runDryCheck,
@@ -154,7 +153,5 @@ import {
   type TaskState,
 } from '@flatbread/proof';
 ```
-
-Note: `createModelResolver` is deprecated in favor of `createModelSelectionResolver` when you need param support (the deprecated helper only returns `ModelSelection.id` and drops `params`).
 
 The public API includes DAG parsing and rank computation, model resolution, canvas state types, convergence helpers, dry command checks, oracle and pause helpers, and self-hosting state utilities.

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -155,4 +155,6 @@ import {
 } from '@flatbread/proof';
 ```
 
+Note: `createModelResolver` is deprecated in favor of `createModelSelectionResolver` when you need param support (the deprecated helper only returns `ModelSelection.id` and drops `params`).
+
 The public API includes DAG parsing and rank computation, model resolution, canvas state types, convergence helpers, dry command checks, oracle and pause helpers, and self-hosting state utilities.

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -68,20 +68,17 @@ Every DAG has a `title` and a `tasks` array. Each task needs:
 
 Proof computes ranks with Kahn topological sort and runs sibling tasks in the same rank concurrently. Avoid placing two sibling tasks in the same rank if they write the same files.
 
-Optional top-level `models` can override the default complexity map with SDK
-model selections:
+Optional top-level `models` can override the default complexity map with plain
+SDK model id strings or SDK model selections:
 
 ```json
 {
   "models": {
     "HIGH": {
-      "id": "claude-opus-4-7",
-      "params": [
-        { "id": "thinking", "value": "true" },
-        { "id": "effort", "value": "max" }
-      ]
+      "id": "gpt-5.4",
+      "params": [{ "id": "reasoning", "value": "high" }]
     },
-    "MED": { "id": "composer-2" },
+    "MED": "composer-2",
     "LOW": {
       "id": "gpt-5.4-nano",
       "params": [{ "id": "reasoning", "value": "low" }]
@@ -89,6 +86,9 @@ model selections:
   }
 }
 ```
+
+Use the object shape when you need `params`; use a string when the model id is
+enough. For example, use `{ "id": "gpt-5.4", "params": [{ "id": "reasoning", "value": "high" }] }`, not a suffix-style id like `gpt-5.4-high`.
 
 When a DAG runs, Proof calls `Cursor.models.list()`, validates model ids and
 param values, and expands partial selections to the closest valid SDK preset

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -68,6 +68,33 @@ Every DAG has a `title` and a `tasks` array. Each task needs:
 
 Proof computes ranks with Kahn topological sort and runs sibling tasks in the same rank concurrently. Avoid placing two sibling tasks in the same rank if they write the same files.
 
+Optional top-level `models` can override the default complexity map with either
+plain SDK model ids or SDK model selections:
+
+```json
+{
+  "models": {
+    "HIGH": {
+      "id": "claude-opus-4-7",
+      "params": [
+        { "id": "thinking", "value": "true" },
+        { "id": "effort", "value": "max" }
+      ]
+    },
+    "MED": "composer-2",
+    "LOW": {
+      "id": "gpt-5.4-nano",
+      "params": [{ "id": "reasoning", "value": "low" }]
+    }
+  }
+}
+```
+
+When a DAG runs, Proof calls `Cursor.models.list()`, validates model ids and
+param values, and expands partial selections to the closest valid SDK preset
+variant using that model's default variant for omitted params. `--init-only`
+does not call the SDK, so it can still render a canvas without `CURSOR_API_KEY`.
+
 Optional task kinds add control gates:
 
 - `kind: "oracle"` runs a shell command and records pass/fail evidence.
@@ -118,8 +145,10 @@ Proof also exposes helpers for tooling:
 ```ts
 import {
   computeRanks,
+  createModelSelectionResolver,
   createModelResolver,
   parseDAG,
+  resolveModelSelectionFromCatalog,
   runDryCheck,
   type DAG,
   type TaskState,

--- a/packages/proof/src/canvas_writer.ts
+++ b/packages/proof/src/canvas_writer.ts
@@ -233,6 +233,7 @@ type TaskStatus =
 type Complexity = 'HIGH' | 'MED' | 'LOW';
 type TaskKind = 'task' | 'pause' | 'oracle';
 
+// Keep in sync with ModelParameterValue / ModelSelection in dag.ts.
 interface ModelParameterValue {
   id: string;
   value: string;

--- a/packages/proof/src/canvas_writer.ts
+++ b/packages/proof/src/canvas_writer.ts
@@ -233,6 +233,16 @@ type TaskStatus =
 type Complexity = 'HIGH' | 'MED' | 'LOW';
 type TaskKind = 'task' | 'pause' | 'oracle';
 
+interface ModelParameterValue {
+  id: string;
+  value: string;
+}
+
+interface ModelSelection {
+  id: string;
+  params?: ModelParameterValue[];
+}
+
 interface TaskState {
   id: string;
   depends_on: string[];
@@ -240,6 +250,7 @@ interface TaskState {
   subtask_prompt: string;
   status: TaskStatus;
   model: string;
+  modelSelection?: ModelSelection;
   kind?: TaskKind;
   command?: string;
   expect?: string;

--- a/packages/proof/src/canvas_writer.ts
+++ b/packages/proof/src/canvas_writer.ts
@@ -713,6 +713,12 @@ function TaskList({
                     : ''}
                   {(t.iteration ?? 0) > 0 ? ' · iteration ' + t.iteration : ''}
                 </Text>
+                {t.modelSelection?.params && t.modelSelection.params.length > 0 ? (
+                  <Text size="small" tone="tertiary" style={{ paddingLeft: 12 }}>
+                    {'Params: ' +
+                      t.modelSelection.params.map((p) => p.id + '=' + p.value).join(', ')}
+                  </Text>
+                ) : null}
                 {effectiveKind(t) === 'pause' && t.checkpointPath ? (
                   <Stack gap={4}>
                     <Text size="small" weight="semibold">

--- a/packages/proof/src/canvas_writer.ts
+++ b/packages/proof/src/canvas_writer.ts
@@ -10,7 +10,15 @@
 
 import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import type { Complexity, DAG, TaskKind } from './dag.js';
+import {
+  formatModelSelection,
+  normalizeModelSelection,
+  type Complexity,
+  type DAG,
+  type ModelSelection,
+  type ModelSpec,
+  type TaskKind,
+} from './dag.js';
 
 export type TaskStatus =
   | 'PENDING'
@@ -27,6 +35,7 @@ export interface TaskState {
   subtask_prompt: string;
   status: TaskStatus;
   model: string;
+  modelSelection?: ModelSelection;
   /** `'task'` (default), `'pause'`, or `'oracle'`. Undefined is normalized to `'task'`. */
   kind?: TaskKind;
   /**
@@ -91,25 +100,34 @@ export interface RunState {
 
 export function initialRunState(
   dag: DAG,
-  modelFor: (c: Complexity) => string
+  modelFor: (c: Complexity) => ModelSpec
 ): RunState {
   return {
     title: dag.title,
     startedAt: Date.now(),
-    tasks: dag.tasks.map((t) => ({
-      id: t.id,
-      depends_on: t.depends_on,
-      complexity: t.complexity,
-      subtask_prompt: t.subtask_prompt,
-      status: 'PENDING',
-      model: modelFor(t.complexity),
-      // Normalize undefined kind → 'task' so downstream consumers (canvas
-      // template, runner dispatcher) never have to ?? again.
-      kind: t.kind ?? 'task',
-      // Surface oracle-only fields so the canvas can render the gate's
-      // command / expectation without reading the streamed result body.
-      ...(t.kind === 'oracle' ? { command: t.command, expect: t.expect } : {}),
-    })),
+    tasks: dag.tasks.map((t) => {
+      const modelSelection = normalizeModelSelection(
+        modelFor(t.complexity),
+        `model for task ${t.id}`
+      );
+      return {
+        id: t.id,
+        depends_on: t.depends_on,
+        complexity: t.complexity,
+        subtask_prompt: t.subtask_prompt,
+        status: 'PENDING',
+        model: formatModelSelection(modelSelection),
+        modelSelection,
+        // Normalize undefined kind → 'task' so downstream consumers (canvas
+        // template, runner dispatcher) never have to ?? again.
+        kind: t.kind ?? 'task',
+        // Surface oracle-only fields so the canvas can render the gate's
+        // command / expectation without reading the streamed result body.
+        ...(t.kind === 'oracle'
+          ? { command: t.command, expect: t.expect }
+          : {}),
+      };
+    }),
   };
 }
 

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -1,0 +1,104 @@
+import test from 'ava';
+
+import {
+  resolveModelSelectionFromCatalog,
+  type ModelCatalogItem,
+  type ModelSelection,
+} from './dag';
+
+function resolveSelection(
+  selection: ModelSelection,
+  variants: NonNullable<ModelCatalogItem['variants']>
+): ModelSelection {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2', variants },
+  ];
+  return resolveModelSelectionFromCatalog(selection, catalog, 'test model');
+}
+
+test('resolveModelSelectionFromCatalog prefers highest-scoring variant among matches', (t) => {
+  const resolved = resolveSelection(
+    { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+    [
+      {
+        displayName: 'Default medium concise',
+        isDefault: true,
+        params: [
+          { id: 'effort', value: 'medium' },
+          { id: 'style', value: 'concise' },
+        ],
+      },
+      {
+        displayName: 'Max concise',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'concise' },
+        ],
+      },
+      {
+        displayName: 'Max verbose',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'verbose' },
+        ],
+      },
+    ]
+  );
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [
+      { id: 'effort', value: 'max' },
+      { id: 'style', value: 'concise' },
+    ],
+  });
+});
+
+test('resolveModelSelectionFromCatalog breaks equal-score ties to catalog default variant', (t) => {
+  const resolved = resolveSelection(
+    { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+    [
+      {
+        displayName: 'Max with style override',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'verbose' },
+        ],
+      },
+      {
+        displayName: 'Default max',
+        isDefault: true,
+        params: [{ id: 'effort', value: 'max' }],
+      },
+    ]
+  );
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'max' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog throws a descriptive error when no variant matches', (t) => {
+  const err = t.throws(() =>
+    resolveSelection(
+      { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+      [
+        {
+          displayName: 'Default medium',
+          isDefault: true,
+          params: [{ id: 'effort', value: 'medium' }],
+        },
+      ]
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected no-match variant selection to throw.');
+    return;
+  }
+  t.regex(
+    err.message,
+    /does not match any Cursor SDK preset variant\. Valid variants:/
+  );
+});

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -102,3 +102,50 @@ test('resolveModelSelectionFromCatalog throws a descriptive error when no varian
     /does not match any Cursor SDK preset variant\. Valid variants:/
   );
 });
+
+test('resolveModelSelectionFromCatalog returns default variant when no params requested', (t) => {
+  const resolved = resolveSelection({ id: 'composer-2' }, [
+    {
+      displayName: 'Fast',
+      params: [{ id: 'effort', value: 'low' }],
+    },
+    {
+      displayName: 'Default',
+      isDefault: true,
+      params: [{ id: 'effort', value: 'medium' }],
+    },
+  ]);
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'medium' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog throws on unknown model id', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2' },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog({ id: 'unknown-model' }, catalog, 'test')
+  );
+
+  if (!err) {
+    t.fail('Expected unknown model id to throw.');
+    return;
+  }
+  t.regex(err.message, /uses unknown Cursor SDK model/);
+});
+
+test('resolveModelSelectionFromCatalog passes through selection when model has no variants', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2' },
+  ];
+  const selection: ModelSelection = {
+    id: 'composer-2',
+  };
+  const resolved = resolveModelSelectionFromCatalog(selection, catalog, 'test');
+
+  t.deepEqual(resolved, selection);
+  t.not(resolved, selection);
+});

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -1,8 +1,11 @@
 import test from 'ava';
 
 import {
+  createModelSelectionResolver,
   normalizeModelSelection,
+  parseDAG,
   resolveModelSelectionFromCatalog,
+  validateModelMap,
   type ModelCatalogItem,
   type ModelSpec,
   type ModelSelection,
@@ -350,4 +353,86 @@ test('normalizeModelSelection throws label-prefixed errors for invalid param val
     }
     t.is(err.message, 'test model.params[0].value must be a non-empty string.');
   }
+});
+
+test('validateModelMap accepts plain string model ids', (t) => {
+  t.deepEqual(
+    validateModelMap(
+      {
+        HIGH: '  claude-opus-4-7  ',
+        LOW: 'gpt-5.4-nano',
+      },
+      'test models'
+    ),
+    {
+      HIGH: { id: 'claude-opus-4-7' },
+      LOW: { id: 'gpt-5.4-nano' },
+    }
+  );
+});
+
+test('validateModelMap accepts model selection objects with params', (t) => {
+  t.deepEqual(
+    validateModelMap(
+      {
+        MED: {
+          id: 'composer-2',
+          params: [{ id: 'effort', value: 'max' }],
+        },
+      },
+      'test models'
+    ),
+    {
+      MED: {
+        id: 'composer-2',
+        params: [{ id: 'effort', value: 'max' }],
+      },
+    }
+  );
+});
+
+test('createModelSelectionResolver normalizes mixed override shapes', (t) => {
+  const modelFor = createModelSelectionResolver({
+    HIGH: 'claude-opus-4-7',
+    MED: {
+      id: 'composer-2',
+      params: [{ id: 'effort', value: 'medium' }],
+    },
+  });
+
+  t.deepEqual(modelFor('HIGH'), { id: 'claude-opus-4-7' });
+  t.deepEqual(modelFor('MED'), {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'medium' }],
+  });
+  t.deepEqual(modelFor('LOW'), { id: 'gpt-5.4-nano' });
+});
+
+test('parseDAG normalizes mixed model override shapes', (t) => {
+  const dag = parseDAG({
+    title: 'Mixed model overrides',
+    models: {
+      HIGH: 'claude-opus-4-7',
+      MED: {
+        id: 'composer-2',
+        params: [{ id: 'effort', value: 'medium' }],
+      },
+    },
+    tasks: [
+      {
+        id: 'review',
+        depends_on: [],
+        complexity: 'HIGH',
+        subtask_prompt: 'Review the change.',
+      },
+    ],
+  });
+
+  t.deepEqual(dag.models, {
+    HIGH: { id: 'claude-opus-4-7' },
+    MED: {
+      id: 'composer-2',
+      params: [{ id: 'effort', value: 'medium' }],
+    },
+  });
 });

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -321,6 +321,21 @@ test('normalizeModelSelection trims string model ids', (t) => {
   t.deepEqual(normalizeModelSelection('  composer-2  '), { id: 'composer-2' });
 });
 
+test('normalizeModelSelection normalizes valid object model specs', (t) => {
+  const input: ModelSelection = {
+    id: '  composer-2  ',
+    params: [{ id: '  effort  ', value: '  medium  ' }],
+  };
+  const result = normalizeModelSelection(input, 'test model');
+
+  t.deepEqual(result, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'medium' }],
+  });
+  t.not(result, input);
+  t.not(result.params, input.params);
+});
+
 test('normalizeModelSelection throws label-prefixed errors for invalid model specs', (t) => {
   for (const raw of ['', '   ', 42, null]) {
     const err = t.throws(() =>
@@ -353,6 +368,27 @@ test('normalizeModelSelection throws label-prefixed errors for invalid param val
     }
     t.is(err.message, 'test model.params[0].value must be a non-empty string.');
   }
+});
+
+test('normalizeModelSelection throws on duplicate param ids', (t) => {
+  const err = t.throws(() =>
+    normalizeModelSelection(
+      {
+        id: 'composer-2',
+        params: [
+          { id: 'effort', value: 'low' },
+          { id: 'effort', value: 'high' },
+        ],
+      },
+      'test model'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected duplicate param id to throw.');
+    return;
+  }
+  t.regex(err.message, /duplicate id: effort/);
 });
 
 test('validateModelMap accepts plain string model ids', (t) => {

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -1,8 +1,10 @@
 import test from 'ava';
 
 import {
+  normalizeModelSelection,
   resolveModelSelectionFromCatalog,
   type ModelCatalogItem,
+  type ModelSpec,
   type ModelSelection,
 } from './dag.js';
 
@@ -122,6 +124,79 @@ test('resolveModelSelectionFromCatalog returns default variant when no params re
   });
 });
 
+test('resolveModelSelectionFromCatalog falls back to first variant when no default is flagged', (t) => {
+  const resolved = resolveSelection({ id: 'composer-2' }, [
+    {
+      displayName: 'Fast',
+      params: [{ id: 'effort', value: 'low' }],
+    },
+    {
+      displayName: 'Careful',
+      params: [{ id: 'effort', value: 'high' }],
+    },
+  ]);
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'low' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog treats empty params as no params requested', (t) => {
+  const resolved = resolveSelection({ id: 'composer-2', params: [] }, [
+    {
+      displayName: 'Fast',
+      params: [{ id: 'effort', value: 'low' }],
+    },
+    {
+      displayName: 'Default',
+      isDefault: true,
+      params: [{ id: 'effort', value: 'medium' }],
+    },
+  ]);
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'medium' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog throws when no variant fully matches requested params', (t) => {
+  const err = t.throws(() =>
+    resolveSelection(
+      {
+        id: 'composer-2',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'verbose' },
+        ],
+      },
+      [
+        {
+          displayName: 'Max concise',
+          params: [
+            { id: 'effort', value: 'max' },
+            { id: 'style', value: 'concise' },
+          ],
+        },
+        {
+          displayName: 'Medium verbose',
+          params: [
+            { id: 'effort', value: 'medium' },
+            { id: 'style', value: 'verbose' },
+          ],
+        },
+      ]
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected partial variant match to throw.');
+    return;
+  }
+  t.regex(err.message, /does not match any Cursor SDK preset variant/);
+});
+
 test('resolveModelSelectionFromCatalog throws on unknown model id', (t) => {
   const catalog: ModelCatalogItem[] = [
     { id: 'composer-2', displayName: 'Composer 2' },
@@ -148,4 +223,131 @@ test('resolveModelSelectionFromCatalog passes through selection when model has n
 
   t.deepEqual(resolved, selection);
   t.not(resolved, selection);
+});
+
+test('resolveModelSelectionFromCatalog accepts valid params declared by catalog parameters', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    {
+      id: 'composer-2',
+      displayName: 'Composer 2',
+      parameters: [
+        {
+          id: 'effort',
+          values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
+        },
+      ],
+    },
+  ];
+  const selection: ModelSelection = {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'high' }],
+  };
+
+  const resolved = resolveModelSelectionFromCatalog(selection, catalog, 'test');
+
+  t.deepEqual(resolved, selection);
+  t.not(resolved, selection);
+});
+
+test('resolveModelSelectionFromCatalog throws when catalog parameters reject a param id', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    {
+      id: 'composer-2',
+      displayName: 'Composer 2',
+      parameters: [{ id: 'effort', values: [{ value: 'medium' }] }],
+    },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog(
+      { id: 'composer-2', params: [{ id: 'style', value: 'concise' }] },
+      catalog,
+      'test'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected unknown parameter id to throw.');
+    return;
+  }
+  t.regex(err.message, /does not support param "style"/);
+});
+
+test('resolveModelSelectionFromCatalog throws when catalog parameters reject a param value', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    {
+      id: 'composer-2',
+      displayName: 'Composer 2',
+      parameters: [{ id: 'effort', values: [{ value: 'medium' }] }],
+    },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog(
+      { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+      catalog,
+      'test'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected unsupported parameter value to throw.');
+    return;
+  }
+  t.regex(err.message, /param "effort" does not support value "max"/);
+});
+
+test('resolveModelSelectionFromCatalog throws when explicit params have no catalog declaration', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2' },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog(
+      { id: 'composer-2', params: [{ id: 'effort', value: 'medium' }] },
+      catalog,
+      'test'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected undeclared parameters to throw.');
+    return;
+  }
+  t.regex(err.message, /does not declare parameters or preset variants/);
+});
+
+test('normalizeModelSelection trims string model ids', (t) => {
+  t.deepEqual(normalizeModelSelection('  composer-2  '), { id: 'composer-2' });
+});
+
+test('normalizeModelSelection throws label-prefixed errors for invalid model specs', (t) => {
+  for (const raw of ['', '   ', 42, null]) {
+    const err = t.throws(() =>
+      normalizeModelSelection(raw as unknown as ModelSpec, 'test model')
+    );
+
+    if (!err) {
+      t.fail(`Expected invalid model spec ${String(raw)} to throw.`);
+      continue;
+    }
+    t.regex(err.message, /^test model must be /);
+  }
+});
+
+test('normalizeModelSelection throws label-prefixed errors for invalid param values', (t) => {
+  for (const value of ['', '   ', 42]) {
+    const err = t.throws(() =>
+      normalizeModelSelection(
+        {
+          id: 'composer-2',
+          params: [{ id: 'effort', value }],
+        } as unknown as ModelSpec,
+        'test model'
+      )
+    );
+
+    if (!err) {
+      t.fail(`Expected invalid param value ${String(value)} to throw.`);
+      continue;
+    }
+    t.is(err.message, 'test model.params[0].value must be a non-empty string.');
+  }
 });

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -4,7 +4,7 @@ import {
   resolveModelSelectionFromCatalog,
   type ModelCatalogItem,
   type ModelSelection,
-} from './dag';
+} from './dag.js';
 
 function resolveSelection(
   selection: ModelSelection,

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -16,7 +16,7 @@ export interface ModelSelection {
 }
 
 export type ModelSpec = string | ModelSelection;
-export type ModelMap = Record<Complexity, ModelSpec>;
+export type ModelMap = Record<Complexity, ModelSelection>;
 export type ModelMapOverride = Partial<ModelMap>;
 export type ResolvedModelMap = Record<Complexity, ModelSelection>;
 
@@ -148,9 +148,9 @@ export function isOracleTask(task: RawTask): boolean {
  * read the SDK's error-message catalog; do NOT trust `cursor-agent --list-models`.
  */
 export const DEFAULT_MODEL_MAP: ModelMap = {
-  HIGH: 'claude-opus-4-7',
-  MED: 'composer-2',
-  LOW: 'gpt-5.4-nano',
+  HIGH: { id: 'claude-opus-4-7' },
+  MED: { id: 'composer-2' },
+  LOW: { id: 'gpt-5.4-nano' },
 };
 
 export function parseDAG(raw: unknown): DAG {
@@ -516,37 +516,13 @@ export function validateModelMap(
   return models;
 }
 
-/**
- * @deprecated This backward-compat shim intentionally returns only `ModelSelection.id`
- * and silently discards any `params`.
- *
- * If you need param support (including preservation of the full `ModelSelection`),
- * migrate to `createModelSelectionResolver`.
- *
- * This helper is retained for backward compatibility and may be removed in a
- * future release.
- */
-export function createModelResolver(
-  overrides: ModelMapOverride = {}
-): (c: Complexity) => string {
-  const models: ModelMap = { ...DEFAULT_MODEL_MAP, ...overrides };
-  return (c: Complexity): string => {
-    if (!COMPLEXITY_KEYS.includes(c)) {
-      throw new Error(`Unknown complexity: ${c}`);
-    }
-    return normalizeModelSelection(models[c], `model for ${c}`).id;
-  };
-}
-
 export function createModelSelectionResolver(
   overrides: ModelMapOverride = {}
 ): (c: Complexity) => ModelSelection {
-  const models: ModelMap = { ...DEFAULT_MODEL_MAP, ...overrides };
+  const models = resolveModelMap(overrides);
   return (c: Complexity): ModelSelection => {
-    if (!COMPLEXITY_KEYS.includes(c)) {
-      throw new Error(`Unknown complexity: ${c}`);
-    }
-    return normalizeModelSelection(models[c], `model for ${c}`);
+    assertKnownComplexity(c);
+    return cloneModelSelection(models[c]);
   };
 }
 
@@ -568,69 +544,80 @@ export function createCatalogBackedModelResolver(
   };
 }
 
-/**
- * Validate a JSON model override without changing its nominal shape: plain
- * strings stay strings so `parseDAG` / `validateModelMap` remain
- * round-trip-stable for legacy configs. Use `normalizeModelSelection` when
- * you need a `ModelSelection` object (including `{ id }` for strings).
- */
+/** Validate a JSON model selection object. */
 export function validateModelSelection(
   raw: unknown,
   label = 'model'
-): ModelSpec {
-  if (typeof raw === 'string') {
-    const id = raw.trim();
-    if (id === '') {
-      throw new Error(`${label} must be a non-empty string or model object.`);
-    }
-    return id;
-  }
+): ModelSelection {
+  const obj = validateModelSelectionObject(raw, label);
+  const id = validateModelId(obj.id, `${label}.id`);
+  const params = validateModelParams(obj.params, label);
+  return createModelSelection(id, params);
+}
+
+function validateModelSelectionObject(
+  raw: unknown,
+  label: string
+): Record<string, unknown> {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    throw new Error(`${label} must be a non-empty string or model object.`);
+    throw new Error(`${label} must be a model object.`);
   }
-  const obj = raw as Record<string, unknown>;
-  const id = obj.id;
-  if (typeof id !== 'string' || id.trim() === '') {
-    throw new Error(`${label}.id must be a non-empty string.`);
+  return raw as Record<string, unknown>;
+}
+
+function validateModelId(raw: unknown, label: string): string {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    throw new Error(`${label} must be a non-empty string.`);
   }
-  if (obj.params === undefined) {
-    return { id: id.trim() };
-  }
-  if (!Array.isArray(obj.params)) {
+  return raw.trim();
+}
+
+function validateModelParams(
+  raw: unknown,
+  label: string
+): ModelParameterValue[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
     throw new Error(`${label}.params must be an array when set.`);
   }
+
   const params: ModelParameterValue[] = [];
   const seen = new Set<string>();
-  for (let i = 0; i < obj.params.length; i++) {
-    const rawParam = obj.params[i];
-    if (!rawParam || typeof rawParam !== 'object' || Array.isArray(rawParam)) {
-      throw new Error(`${label}.params[${i}] must be an object.`);
-    }
-    const param = rawParam as Record<string, unknown>;
-    if (typeof param.id !== 'string' || param.id.trim() === '') {
-      throw new Error(`${label}.params[${i}].id must be a non-empty string.`);
-    }
-    if (typeof param.value !== 'string' || param.value.trim() === '') {
-      throw new Error(
-        `${label}.params[${i}].value must be a non-empty string.`
-      );
-    }
-    const paramId = param.id.trim();
+  for (let i = 0; i < raw.length; i++) {
+    const param = validateModelParam(raw[i], label, i);
+    const paramId = param.id;
     if (seen.has(paramId)) {
       throw new Error(`${label}.params contains duplicate id: ${paramId}`);
     }
     seen.add(paramId);
-    params.push({ id: paramId, value: param.value.trim() });
+    params.push(param);
   }
-  return params.length > 0 ? { id: id.trim(), params } : { id: id.trim() };
+  return params;
+}
+
+function validateModelParam(
+  raw: unknown,
+  label: string,
+  index: number
+): ModelParameterValue {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${label}.params[${index}] must be an object.`);
+  }
+  const param = raw as Record<string, unknown>;
+  return {
+    id: validateModelId(param.id, `${label}.params[${index}].id`),
+    value: validateModelId(param.value, `${label}.params[${index}].value`),
+  };
 }
 
 export function normalizeModelSelection(
   raw: ModelSpec,
   label = 'model'
 ): ModelSelection {
-  const spec = validateModelSelection(raw, label);
-  return typeof spec === 'string' ? { id: spec } : spec;
+  if (typeof raw === 'string') {
+    return createModelSelection(validateModelId(raw, label));
+  }
+  return validateModelSelection(raw, label);
 }
 
 export function formatModelSelection(model: ModelSelection): string {
@@ -748,6 +735,20 @@ function defaultVariant(
   return variants.find((variant) => variant.isDefault) ?? variants[0];
 }
 
+function assertKnownComplexity(c: Complexity): void {
+  if (!COMPLEXITY_KEYS.includes(c)) {
+    throw new Error(`Unknown complexity: ${c}`);
+  }
+}
+
+function resolveModelMap(overrides: ModelMapOverride = {}): ModelMap {
+  return {
+    HIGH: cloneModelSelection(overrides.HIGH ?? DEFAULT_MODEL_MAP.HIGH),
+    MED: cloneModelSelection(overrides.MED ?? DEFAULT_MODEL_MAP.MED),
+    LOW: cloneModelSelection(overrides.LOW ?? DEFAULT_MODEL_MAP.LOW),
+  };
+}
+
 function chooseMatchingVariant(
   requestedParams: readonly ModelParameterValue[],
   variants: ReadonlyArray<ModelCatalogVariant>
@@ -818,9 +819,15 @@ function formatVariants(variants: ReadonlyArray<ModelCatalogVariant>): string {
     .join('\n  ');
 }
 
+function createModelSelection(
+  id: string,
+  params: readonly ModelParameterValue[] = []
+): ModelSelection {
+  return params.length > 0
+    ? { id, params: params.map((param) => ({ ...param })) }
+    : { id };
+}
+
 function cloneModelSelection(selection: ModelSelection): ModelSelection {
-  const params = selection.params?.map((param) => ({ ...param }));
-  return params && params.length > 0
-    ? { id: selection.id, params }
-    : { id: selection.id };
+  return createModelSelection(selection.id, selection.params ?? []);
 }

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -574,7 +574,10 @@ export function createCatalogBackedModelResolver(
  * round-trip-stable for legacy configs. Use `normalizeModelSelection` when
  * you need a `ModelSelection` object (including `{ id }` for strings).
  */
-export function validateModelSelection(raw: unknown, label = 'model'): ModelSpec {
+export function validateModelSelection(
+  raw: unknown,
+  label = 'model'
+): ModelSpec {
   if (typeof raw === 'string') {
     const id = raw.trim();
     if (id === '') {
@@ -706,9 +709,11 @@ function validateRequestedParams(
       const allowed = new Set(definition.values.map((value) => value.value));
       if (!allowed.has(param.value)) {
         throw new Error(
-          `${label} ${selection.id} param "${param.id}" does not support value "${
-            param.value
-          }". Supported values: ${[...allowed].join(', ')}`
+          `${label} ${selection.id} param "${
+            param.id
+          }" does not support value "${param.value}". Supported values: ${[
+            ...allowed,
+          ].join(', ')}`
         );
       }
     }
@@ -765,7 +770,11 @@ function chooseMatchingVariant(
     if (score > bestScore) {
       best = match;
       bestScore = score;
-    } else if (score === bestScore && match === defaultVar && best !== defaultVar) {
+    } else if (
+      score === bestScore &&
+      match === defaultVar &&
+      best !== defaultVar
+    ) {
       best = match;
     }
   }

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -550,7 +550,7 @@ export function validateModelSelection(
   label = 'model'
 ): ModelSelection {
   const obj = validateModelSelectionObject(raw, label);
-  const id = validateModelId(obj.id, `${label}.id`);
+  const id = validateNonEmptyString(obj.id, `${label}.id`);
   const params = validateModelParams(obj.params, label);
   return createModelSelection(id, params);
 }
@@ -565,7 +565,7 @@ function validateModelSelectionObject(
   return raw as Record<string, unknown>;
 }
 
-function validateModelId(raw: unknown, label: string): string {
+function validateNonEmptyString(raw: unknown, label: string): string {
   if (typeof raw !== 'string' || raw.trim() === '') {
     throw new Error(`${label} must be a non-empty string.`);
   }
@@ -605,8 +605,11 @@ function validateModelParam(
   }
   const param = raw as Record<string, unknown>;
   return {
-    id: validateModelId(param.id, `${label}.params[${index}].id`),
-    value: validateModelId(param.value, `${label}.params[${index}].value`),
+    id: validateNonEmptyString(param.id, `${label}.params[${index}].id`),
+    value: validateNonEmptyString(
+      param.value,
+      `${label}.params[${index}].value`
+    ),
   };
 }
 
@@ -615,7 +618,7 @@ export function normalizeModelSelection(
   label = 'model'
 ): ModelSelection {
   if (typeof raw === 'string') {
-    return createModelSelection(validateModelId(raw, label));
+    return createModelSelection(validateNonEmptyString(raw, label));
   }
   return validateModelSelection(raw, label);
 }

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -631,9 +631,9 @@ export function resolveModelSelectionFromCatalog(
   if (!catalogItem) {
     const ids = catalog.map((model) => model.id).sort();
     throw new Error(
-      `${label} uses unknown Cursor SDK model "${selection.id}". Known models:\n  ${ids.join(
-        '\n  '
-      )}`
+      `${label} uses unknown Cursor SDK model "${
+        selection.id
+      }". Known models:\n  ${ids.join('\n  ')}`
     );
   }
 
@@ -661,7 +661,9 @@ export function resolveModelSelectionFromCatalog(
   }
 
   const params = chosenVariant.params.map((param) => ({ ...param }));
-  return params.length > 0 ? { id: selection.id, params } : { id: selection.id };
+  return params.length > 0
+    ? { id: selection.id, params }
+    : { id: selection.id };
 }
 
 function validateRequestedParams(
@@ -678,7 +680,9 @@ function validateRequestedParams(
     if (!definition) {
       const supported = [...definitions.keys()].sort();
       throw new Error(
-        `${label} ${selection.id} does not support param "${param.id}". Supported params: ${
+        `${label} ${selection.id} does not support param "${
+          param.id
+        }". Supported params: ${
           supported.length > 0 ? supported.join(', ') : '(none)'
         }`
       );
@@ -686,9 +690,9 @@ function validateRequestedParams(
     const allowed = new Set(definition.values.map((value) => value.value));
     if (!allowed.has(param.value)) {
       throw new Error(
-        `${label} ${selection.id} param "${param.id}" does not support value "${param.value}". Supported values: ${[
-          ...allowed,
-        ].join(', ')}`
+        `${label} ${selection.id} param "${param.id}" does not support value "${
+          param.value
+        }". Supported values: ${[...allowed].join(', ')}`
       );
     }
   }
@@ -752,9 +756,7 @@ function scoreVariant(
   return score;
 }
 
-function formatVariants(
-  variants: ReadonlyArray<ModelCatalogVariant>
-): string {
+function formatVariants(variants: ReadonlyArray<ModelCatalogVariant>): string {
   return variants
     .map((variant) => {
       const params = variant.params

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -17,7 +17,7 @@ export interface ModelSelection {
 
 export type ModelSpec = string | ModelSelection;
 export type ModelMap = Record<Complexity, ModelSelection>;
-export type ModelMapOverride = Partial<ModelMap>;
+export type ModelMapOverride = Partial<Record<Complexity, ModelSpec>>;
 export type ResolvedModelMap = Record<Complexity, ModelSelection>;
 
 export interface ModelCatalogItem {
@@ -508,8 +508,8 @@ export function validateModelMap(
     if (!COMPLEXITY_VALUES.has(key as Complexity)) {
       throw new Error(`${label} contains unknown complexity key: ${key}`);
     }
-    models[key as Complexity] = validateModelSelection(
-      value,
+    models[key as Complexity] = normalizeModelSelection(
+      value as ModelSpec,
       `${label}.${key}`
     );
   }
@@ -746,9 +746,9 @@ function assertKnownComplexity(c: Complexity): void {
 
 function resolveModelMap(overrides: ModelMapOverride = {}): ModelMap {
   return {
-    HIGH: cloneModelSelection(overrides.HIGH ?? DEFAULT_MODEL_MAP.HIGH),
-    MED: cloneModelSelection(overrides.MED ?? DEFAULT_MODEL_MAP.MED),
-    LOW: cloneModelSelection(overrides.LOW ?? DEFAULT_MODEL_MAP.LOW),
+    HIGH: normalizeModelSelection(overrides.HIGH ?? DEFAULT_MODEL_MAP.HIGH),
+    MED: normalizeModelSelection(overrides.MED ?? DEFAULT_MODEL_MAP.MED),
+    LOW: normalizeModelSelection(overrides.LOW ?? DEFAULT_MODEL_MAP.LOW),
   };
 }
 

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -516,6 +516,16 @@ export function validateModelMap(
   return models;
 }
 
+/**
+ * @deprecated This backward-compat shim intentionally returns only `ModelSelection.id`
+ * and silently discards any `params`.
+ *
+ * If you need param support (including preservation of the full `ModelSelection`),
+ * migrate to `createModelSelectionResolver`.
+ *
+ * This helper is retained for backward compatibility and may be removed in a
+ * future release.
+ */
 export function createModelResolver(
   overrides: ModelMapOverride = {}
 ): (c: Complexity) => string {
@@ -715,17 +725,21 @@ function chooseMatchingVariant(
   );
   if (matches.length === 0) return undefined;
 
+  const defaultVar = defaultVariant(variants);
   const defaultParams = new Map(
-    defaultVariant(variants).params.map((param) => [param.id, param.value])
+    defaultVar.params.map((param) => [param.id, param.value])
   );
   const requestedIds = new Set(requestedParams.map((param) => param.id));
   let best = matches[0];
   let bestScore = scoreVariant(best.params, defaultParams, requestedIds);
+  // Ties break to the catalog-declared default variant; otherwise first match wins.
   for (const match of matches.slice(1)) {
     const score = scoreVariant(match.params, defaultParams, requestedIds);
     if (score > bestScore) {
       best = match;
       bestScore = score;
+    } else if (score === bestScore && match === defaultVar && best !== defaultVar) {
+      best = match;
     }
   }
   return best;

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -568,16 +568,19 @@ export function createCatalogBackedModelResolver(
   };
 }
 
-export function validateModelSelection(
-  raw: unknown,
-  label = 'model'
-): ModelSelection {
+/**
+ * Validate a JSON model override without changing its nominal shape: plain
+ * strings stay strings so `parseDAG` / `validateModelMap` remain
+ * round-trip-stable for legacy configs. Use `normalizeModelSelection` when
+ * you need a `ModelSelection` object (including `{ id }` for strings).
+ */
+export function validateModelSelection(raw: unknown, label = 'model'): ModelSpec {
   if (typeof raw === 'string') {
     const id = raw.trim();
     if (id === '') {
       throw new Error(`${label} must be a non-empty string or model object.`);
     }
-    return { id };
+    return id;
   }
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error(`${label} must be a non-empty string or model object.`);
@@ -623,7 +626,8 @@ export function normalizeModelSelection(
   raw: ModelSpec,
   label = 'model'
 ): ModelSelection {
-  return validateModelSelection(raw, label);
+  const spec = validateModelSelection(raw, label);
+  return typeof spec === 'string' ? { id: spec } : spec;
 }
 
 export function formatModelSelection(model: ModelSelection): string {
@@ -681,31 +685,54 @@ function validateRequestedParams(
   catalogItem: ModelCatalogItem,
   label: string
 ): void {
-  const definitions = new Map(
-    (catalogItem.parameters ?? []).map((param) => [param.id, param])
-  );
   const requestedParams = selection.params ?? [];
-  for (const param of requestedParams) {
-    const definition = definitions.get(param.id);
-    if (!definition) {
-      const supported = [...definitions.keys()].sort();
-      throw new Error(
-        `${label} ${selection.id} does not support param "${
-          param.id
-        }". Supported params: ${
-          supported.length > 0 ? supported.join(', ') : '(none)'
-        }`
-      );
+  if (requestedParams.length === 0) return;
+
+  const paramDefs = catalogItem.parameters ?? [];
+  if (paramDefs.length > 0) {
+    const definitions = new Map(paramDefs.map((param) => [param.id, param]));
+    for (const param of requestedParams) {
+      const definition = definitions.get(param.id);
+      if (!definition) {
+        const supported = [...definitions.keys()].sort();
+        throw new Error(
+          `${label} ${selection.id} does not support param "${
+            param.id
+          }". Supported params: ${
+            supported.length > 0 ? supported.join(', ') : '(none)'
+          }`
+        );
+      }
+      const allowed = new Set(definition.values.map((value) => value.value));
+      if (!allowed.has(param.value)) {
+        throw new Error(
+          `${label} ${selection.id} param "${param.id}" does not support value "${
+            param.value
+          }". Supported values: ${[...allowed].join(', ')}`
+        );
+      }
     }
-    const allowed = new Set(definition.values.map((value) => value.value));
-    if (!allowed.has(param.value)) {
-      throw new Error(
-        `${label} ${selection.id} param "${param.id}" does not support value "${
-          param.value
-        }". Supported values: ${[...allowed].join(', ')}`
-      );
-    }
+    return;
   }
+
+  const variants = catalogItem.variants ?? [];
+  if (variants.length > 0) {
+    const chosenVariant = chooseMatchingVariant(requestedParams, variants);
+    if (!chosenVariant) {
+      throw new Error(
+        `${label} ${formatModelSelection(
+          selection
+        )} does not match any Cursor SDK preset variant. Valid variants:\n  ${formatVariants(
+          variants
+        )}`
+      );
+    }
+    return;
+  }
+
+  throw new Error(
+    `${label} ${selection.id} does not declare parameters or preset variants in the Cursor SDK catalog; remove explicit params from this model selection.`
+  );
 }
 
 type ModelCatalogVariant = NonNullable<ModelCatalogItem['variants']>[number];

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -5,8 +5,36 @@
  */
 
 export type Complexity = 'HIGH' | 'MED' | 'LOW';
-export type ModelMap = Record<Complexity, string>;
+export interface ModelParameterValue {
+  id: string;
+  value: string;
+}
+
+export interface ModelSelection {
+  id: string;
+  params?: ModelParameterValue[];
+}
+
+export type ModelSpec = string | ModelSelection;
+export type ModelMap = Record<Complexity, ModelSpec>;
 export type ModelMapOverride = Partial<ModelMap>;
+export type ResolvedModelMap = Record<Complexity, ModelSelection>;
+
+export interface ModelCatalogItem {
+  id: string;
+  displayName: string;
+  parameters?: Array<{
+    id: string;
+    displayName?: string;
+    values: Array<{ value: string; displayName?: string }>;
+  }>;
+  variants?: Array<{
+    params: ModelParameterValue[];
+    displayName: string;
+    description?: string;
+    isDefault?: boolean;
+  }>;
+}
 
 /**
  * Discriminator separating LLM-backed work from non-LLM gate nodes.
@@ -78,7 +106,11 @@ export interface DAGBudget {
 }
 
 const COMPLEXITY_VALUES = new Set<Complexity>(['HIGH', 'MED', 'LOW']);
-const COMPLEXITY_KEYS: readonly Complexity[] = ['HIGH', 'MED', 'LOW'] as const;
+export const COMPLEXITY_KEYS: readonly Complexity[] = [
+  'HIGH',
+  'MED',
+  'LOW',
+] as const;
 const TASK_KIND_VALUES = new Set<TaskKind>(['task', 'pause', 'oracle']);
 /** Synthetic placeholder so non-LLM tasks (pause, oracle) satisfy the existing structural type. The runner must branch on `kind` before consuming this. */
 const NON_LLM_SYNTHETIC_COMPLEXITY: Complexity = 'LOW';
@@ -476,10 +508,10 @@ export function validateModelMap(
     if (!COMPLEXITY_VALUES.has(key as Complexity)) {
       throw new Error(`${label} contains unknown complexity key: ${key}`);
     }
-    if (typeof value !== 'string' || value.trim() === '') {
-      throw new Error(`${label}.${key} must be a non-empty string.`);
-    }
-    models[key as Complexity] = value.trim();
+    models[key as Complexity] = validateModelSelection(
+      value,
+      `${label}.${key}`
+    );
   }
   return models;
 }
@@ -492,6 +524,251 @@ export function createModelResolver(
     if (!COMPLEXITY_KEYS.includes(c)) {
       throw new Error(`Unknown complexity: ${c}`);
     }
-    return models[c];
+    return normalizeModelSelection(models[c], `model for ${c}`).id;
   };
+}
+
+export function createModelSelectionResolver(
+  overrides: ModelMapOverride = {}
+): (c: Complexity) => ModelSelection {
+  const models: ModelMap = { ...DEFAULT_MODEL_MAP, ...overrides };
+  return (c: Complexity): ModelSelection => {
+    if (!COMPLEXITY_KEYS.includes(c)) {
+      throw new Error(`Unknown complexity: ${c}`);
+    }
+    return normalizeModelSelection(models[c], `model for ${c}`);
+  };
+}
+
+export function createCatalogBackedModelResolver(
+  modelFor: (c: Complexity) => ModelSelection,
+  catalog: readonly ModelCatalogItem[]
+): (c: Complexity) => ModelSelection {
+  const cache = new Map<Complexity, ModelSelection>();
+  return (c: Complexity): ModelSelection => {
+    const cached = cache.get(c);
+    if (cached) return cloneModelSelection(cached);
+    const resolved = resolveModelSelectionFromCatalog(
+      modelFor(c),
+      catalog,
+      `model for ${c}`
+    );
+    cache.set(c, resolved);
+    return cloneModelSelection(resolved);
+  };
+}
+
+export function validateModelSelection(
+  raw: unknown,
+  label = 'model'
+): ModelSelection {
+  if (typeof raw === 'string') {
+    const id = raw.trim();
+    if (id === '') {
+      throw new Error(`${label} must be a non-empty string or model object.`);
+    }
+    return { id };
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${label} must be a non-empty string or model object.`);
+  }
+  const obj = raw as Record<string, unknown>;
+  const id = obj.id;
+  if (typeof id !== 'string' || id.trim() === '') {
+    throw new Error(`${label}.id must be a non-empty string.`);
+  }
+  if (obj.params === undefined) {
+    return { id: id.trim() };
+  }
+  if (!Array.isArray(obj.params)) {
+    throw new Error(`${label}.params must be an array when set.`);
+  }
+  const params: ModelParameterValue[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < obj.params.length; i++) {
+    const rawParam = obj.params[i];
+    if (!rawParam || typeof rawParam !== 'object' || Array.isArray(rawParam)) {
+      throw new Error(`${label}.params[${i}] must be an object.`);
+    }
+    const param = rawParam as Record<string, unknown>;
+    if (typeof param.id !== 'string' || param.id.trim() === '') {
+      throw new Error(`${label}.params[${i}].id must be a non-empty string.`);
+    }
+    if (typeof param.value !== 'string' || param.value.trim() === '') {
+      throw new Error(
+        `${label}.params[${i}].value must be a non-empty string.`
+      );
+    }
+    const paramId = param.id.trim();
+    if (seen.has(paramId)) {
+      throw new Error(`${label}.params contains duplicate id: ${paramId}`);
+    }
+    seen.add(paramId);
+    params.push({ id: paramId, value: param.value.trim() });
+  }
+  return params.length > 0 ? { id: id.trim(), params } : { id: id.trim() };
+}
+
+export function normalizeModelSelection(
+  raw: ModelSpec,
+  label = 'model'
+): ModelSelection {
+  return validateModelSelection(raw, label);
+}
+
+export function formatModelSelection(model: ModelSelection): string {
+  const params = model.params ?? [];
+  if (params.length === 0) return model.id;
+  return `${model.id} (${params.map((p) => `${p.id}=${p.value}`).join(', ')})`;
+}
+
+export function resolveModelSelectionFromCatalog(
+  selection: ModelSelection,
+  catalog: readonly ModelCatalogItem[],
+  label = 'model'
+): ModelSelection {
+  const catalogItem = catalog.find((model) => model.id === selection.id);
+  if (!catalogItem) {
+    const ids = catalog.map((model) => model.id).sort();
+    throw new Error(
+      `${label} uses unknown Cursor SDK model "${selection.id}". Known models:\n  ${ids.join(
+        '\n  '
+      )}`
+    );
+  }
+
+  validateRequestedParams(selection, catalogItem, label);
+
+  const variants = catalogItem.variants ?? [];
+  if (variants.length === 0) {
+    return cloneModelSelection(selection);
+  }
+
+  const requestedParams = selection.params ?? [];
+  const chosenVariant =
+    requestedParams.length === 0
+      ? defaultVariant(variants)
+      : chooseMatchingVariant(requestedParams, variants);
+
+  if (!chosenVariant) {
+    throw new Error(
+      `${label} ${formatModelSelection(
+        selection
+      )} does not match any Cursor SDK preset variant. Valid variants:\n  ${formatVariants(
+        variants
+      )}`
+    );
+  }
+
+  const params = chosenVariant.params.map((param) => ({ ...param }));
+  return params.length > 0 ? { id: selection.id, params } : { id: selection.id };
+}
+
+function validateRequestedParams(
+  selection: ModelSelection,
+  catalogItem: ModelCatalogItem,
+  label: string
+): void {
+  const definitions = new Map(
+    (catalogItem.parameters ?? []).map((param) => [param.id, param])
+  );
+  const requestedParams = selection.params ?? [];
+  for (const param of requestedParams) {
+    const definition = definitions.get(param.id);
+    if (!definition) {
+      const supported = [...definitions.keys()].sort();
+      throw new Error(
+        `${label} ${selection.id} does not support param "${param.id}". Supported params: ${
+          supported.length > 0 ? supported.join(', ') : '(none)'
+        }`
+      );
+    }
+    const allowed = new Set(definition.values.map((value) => value.value));
+    if (!allowed.has(param.value)) {
+      throw new Error(
+        `${label} ${selection.id} param "${param.id}" does not support value "${param.value}". Supported values: ${[
+          ...allowed,
+        ].join(', ')}`
+      );
+    }
+  }
+}
+
+type ModelCatalogVariant = NonNullable<ModelCatalogItem['variants']>[number];
+
+function defaultVariant(
+  variants: ReadonlyArray<ModelCatalogVariant>
+): ModelCatalogVariant {
+  return variants.find((variant) => variant.isDefault) ?? variants[0];
+}
+
+function chooseMatchingVariant(
+  requestedParams: readonly ModelParameterValue[],
+  variants: ReadonlyArray<ModelCatalogVariant>
+): ModelCatalogVariant | undefined {
+  const matches = variants.filter((variant) =>
+    paramsContainAll(variant.params, requestedParams)
+  );
+  if (matches.length === 0) return undefined;
+
+  const defaultParams = new Map(
+    defaultVariant(variants).params.map((param) => [param.id, param.value])
+  );
+  const requestedIds = new Set(requestedParams.map((param) => param.id));
+  let best = matches[0];
+  let bestScore = scoreVariant(best.params, defaultParams, requestedIds);
+  for (const match of matches.slice(1)) {
+    const score = scoreVariant(match.params, defaultParams, requestedIds);
+    if (score > bestScore) {
+      best = match;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+function paramsContainAll(
+  candidateParams: readonly ModelParameterValue[],
+  requestedParams: readonly ModelParameterValue[]
+): boolean {
+  const candidate = new Map(
+    candidateParams.map((param) => [param.id, param.value])
+  );
+  return requestedParams.every(
+    (param) => candidate.get(param.id) === param.value
+  );
+}
+
+function scoreVariant(
+  params: readonly ModelParameterValue[],
+  defaultParams: ReadonlyMap<string, string>,
+  requestedIds: ReadonlySet<string>
+): number {
+  let score = 0;
+  for (const param of params) {
+    if (requestedIds.has(param.id)) continue;
+    if (defaultParams.get(param.id) === param.value) score++;
+  }
+  return score;
+}
+
+function formatVariants(
+  variants: ReadonlyArray<ModelCatalogVariant>
+): string {
+  return variants
+    .map((variant) => {
+      const params = variant.params
+        .map((param) => `${param.id}=${param.value}`)
+        .join(', ');
+      const suffix = variant.isDefault ? ' [default]' : '';
+      return `${variant.displayName}${suffix}: ${params || '(no params)'}`;
+    })
+    .join('\n  ');
+}
+
+function cloneModelSelection(selection: ModelSelection): ModelSelection {
+  const params = selection.params?.map((param) => ({ ...param }));
+  return params && params.length > 0
+    ? { id: selection.id, params }
+    : { id: selection.id };
 }

--- a/packages/proof/src/index.ts
+++ b/packages/proof/src/index.ts
@@ -13,7 +13,6 @@ export {
   computeRanks,
   createCatalogBackedModelResolver,
   createModelSelectionResolver,
-  createModelResolver,
   formatModelSelection,
   isOracleTask,
   isPauseTask,

--- a/packages/proof/src/index.ts
+++ b/packages/proof/src/index.ts
@@ -8,21 +8,33 @@
  */
 
 export {
+  COMPLEXITY_KEYS,
   DEFAULT_MODEL_MAP,
   computeRanks,
+  createCatalogBackedModelResolver,
+  createModelSelectionResolver,
   createModelResolver,
+  formatModelSelection,
   isOracleTask,
   isPauseTask,
+  normalizeModelSelection,
   parseDAG,
+  resolveModelSelectionFromCatalog,
+  validateModelSelection,
   validateModelMap,
 } from './dag.js';
 export type {
   Complexity,
   DAG,
   DAGBudget,
+  ModelCatalogItem,
   ModelMap,
   ModelMapOverride,
+  ModelParameterValue,
+  ModelSelection,
+  ModelSpec,
   RawTask,
+  ResolvedModelMap,
   TaskKind,
 } from './dag.js';
 

--- a/packages/proof/src/run_dag.ts
+++ b/packages/proof/src/run_dag.ts
@@ -481,6 +481,19 @@ function taskModelSelection(ts: TaskState): ModelSelection {
   );
 }
 
+async function fetchCursorModelCatalog(): Promise<
+  Awaited<ReturnType<typeof Cursor.models.list>>
+> {
+  try {
+    return await Cursor.models.list();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not fetch Cursor model catalog. Check CURSOR_API_KEY and network connectivity. Original error: ${message}`
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
@@ -531,7 +544,7 @@ async function main(): Promise<void> {
     ? unresolvedModelForComplexity
     : createCatalogBackedModelResolver(
         unresolvedModelForComplexity,
-        await Cursor.models.list()
+        await fetchCursorModelCatalog()
       );
   if (!args.initOnly) {
     for (const complexity of COMPLEXITY_KEYS) {

--- a/packages/proof/src/run_dag.ts
+++ b/packages/proof/src/run_dag.ts
@@ -475,6 +475,8 @@ function isResumeTerminalStatus(status: TaskState['status']): boolean {
 function taskModelSelection(ts: TaskState): ModelSelection {
   return (
     ts.modelSelection ??
+    // Fallback path is for legacy persisted run-state (before modelSelection).
+    // In that shape ts.model is always a plain model id (not formatted output).
     normalizeModelSelection(ts.model, `task ${ts.id} model`)
   );
 }

--- a/packages/proof/src/run_dag.ts
+++ b/packages/proof/src/run_dag.ts
@@ -70,7 +70,7 @@
  *                             newly edited source.
  */
 
-import { Agent } from '@cursor/sdk';
+import { Agent, Cursor } from '@cursor/sdk';
 import { existsSync } from 'node:fs';
 import { setMaxListeners } from 'node:events';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
@@ -82,13 +82,19 @@ import { fileURLToPath } from 'node:url';
 
 import {
   parseDAG,
+  COMPLEXITY_KEYS,
   computeRanks,
-  createModelResolver,
+  createCatalogBackedModelResolver,
+  createModelSelectionResolver,
+  formatModelSelection,
+  normalizeModelSelection,
   validateModelMap,
 } from './dag.js';
 import type {
   DAG,
   DAGBudget,
+  ModelSelection,
+  ModelSpec,
   ModelMapOverride,
   RawTask,
   TaskKind,
@@ -406,7 +412,7 @@ function defaultCanvasesDir(cwd: string): string {
 async function loadResumedRunState(
   statePath: string,
   dag: DAG,
-  modelForComplexity: (c: RawTask['complexity']) => string
+  modelForComplexity: (c: RawTask['complexity']) => ModelSpec
 ): Promise<RunState> {
   const persisted = await readPersistedRunState(statePath);
   const state = persisted.state;
@@ -430,7 +436,12 @@ async function loadResumedRunState(
     ts.depends_on = task.depends_on;
     ts.complexity = task.complexity;
     ts.subtask_prompt = task.subtask_prompt;
-    ts.model = modelForComplexity(task.complexity);
+    const modelSelection = normalizeModelSelection(
+      modelForComplexity(task.complexity),
+      `model for task ${task.id}`
+    );
+    ts.model = formatModelSelection(modelSelection);
+    ts.modelSelection = modelSelection;
     ts.kind = task.kind ?? 'task';
     ts.command = task.kind === 'oracle' ? task.command : undefined;
     ts.expect = task.kind === 'oracle' ? task.expect : undefined;
@@ -459,6 +470,10 @@ function isResumeTerminalStatus(status: TaskState['status']): boolean {
   return (
     status === 'FINISHED' || status === 'ERROR' || status === 'BUDGET-EXCEEDED'
   );
+}
+
+function taskModelSelection(ts: TaskState): ModelSelection {
+  return ts.modelSelection ?? normalizeModelSelection(ts.model, `task ${ts.id} model`);
 }
 
 async function main(): Promise<void> {
@@ -504,9 +519,21 @@ async function main(): Promise<void> {
           ),
           `--models-file ${args.modelsFile}`
         );
-  const modelForComplexity = createModelResolver(
+  const unresolvedModelForComplexity = createModelSelectionResolver(
     mergeModelOverrides({ dagModels: dag.models, fileModels })
   );
+  const modelForComplexity = args.initOnly
+    ? unresolvedModelForComplexity
+    : createCatalogBackedModelResolver(
+        unresolvedModelForComplexity,
+        await Cursor.models.list()
+      );
+  if (!args.initOnly) {
+    for (const complexity of COMPLEXITY_KEYS) {
+      modelForComplexity(complexity);
+    }
+    console.log('[proof] validated model selections against Cursor.models.list()');
+  }
   const ranks = computeRanks(dag);
 
   if (args.convergeOn && !dag.tasks.some((t) => t.id === args.convergeOn)) {
@@ -941,10 +968,11 @@ async function runTask(
       ? options.framing.trimEnd() + '\n\n'
       : '';
   const stitched = framing + stitchedBody;
+  const modelSelection = taskModelSelection(ts);
 
   const agent = await Agent.create({
     apiKey: process.env.CURSOR_API_KEY!,
-    model: { id: ts.model },
+    model: modelSelection,
     local: { cwd },
   });
 

--- a/packages/proof/src/run_dag.ts
+++ b/packages/proof/src/run_dag.ts
@@ -473,7 +473,10 @@ function isResumeTerminalStatus(status: TaskState['status']): boolean {
 }
 
 function taskModelSelection(ts: TaskState): ModelSelection {
-  return ts.modelSelection ?? normalizeModelSelection(ts.model, `task ${ts.id} model`);
+  return (
+    ts.modelSelection ??
+    normalizeModelSelection(ts.model, `task ${ts.id} model`)
+  );
 }
 
 async function main(): Promise<void> {
@@ -532,7 +535,9 @@ async function main(): Promise<void> {
     for (const complexity of COMPLEXITY_KEYS) {
       modelForComplexity(complexity);
     }
-    console.log('[proof] validated model selections against Cursor.models.list()');
+    console.log(
+      '[proof] validated model selections against Cursor.models.list()'
+    );
   }
   const ranks = computeRanks(dag);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary of changes**

Adds SDK-style model selections to Proof DAG/model-file config so complexity mappings specify `{ id, params? }`, validates those selections against `Cursor.models.list()` at run time, expands partial param selections to valid preset variants before creating Cursor SDK agents, removes the deprecated `createModelResolver` helper, and migrates checked-in Proof configs/examples to object-based selections.

Closes #

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
- [x] My changes generate no new console errors locally
- [x] If applicable, try to include a test that fails without this PR but passes with it

### Does this introduce any non-backwards compatible changes?

- [x] Yes
  - [x] Proof model overrides now require object selections like `{ "id": "composer-2" }`
- [ ] No

### Does this include any user config changes?

- [x] Yes
  - [x] If so, I have updated the relevant areas of documentation
- [ ] No
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59ff6801-ba7d-485b-aeef-8ed76393da19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59ff6801-ba7d-485b-aeef-8ed76393da19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

