### PR TITLE
docs: add CURSOR_RIPGREP_PATH gotcha for proof package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ The repo uses Mergify stacks for PR management. The `mergify-cli` is installed v
 
 ### Gotchas
 
+- **`@flatbread/proof` requires `CURSOR_RIPGREP_PATH`.** The proof package uses `@cursor/sdk` which expects a bundled ripgrep. In Cloud Agent VMs, set `export CURSOR_RIPGREP_PATH=/usr/bin/rg` to use the system ripgrep (included in the update script).
 - **Native build scripts are approved in `pnpm-workspace.yaml`.** The `onlyBuiltDependencies` list allows esbuild, sharp, @swc/core, etc. to run their postinstall scripts automatically during `pnpm install`.
 - **Vitest packages run in watch mode by default.** Always use `vitest run` (not bare `vitest`) to get a single run and exit.
 - **`flatbread` CLI is not on PATH.** Use `npx flatbread` when running from a shell. The `pnpm play` script from the root handles this automatically.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary of changes**

Adds `CURSOR_RIPGREP_PATH` documentation to `AGENTS.md`. The `@flatbread/proof` package uses `@cursor/sdk` which tries to resolve a bundled ripgrep from `@cursor/sdk-linux-x64`. In Cloud Agent VMs, this optional dependency isn't installed, but system ripgrep is available at `/usr/bin/rg`. Setting `CURSOR_RIPGREP_PATH=/usr/bin/rg` resolves the warning.

The VM update script is also updated to set this env var automatically.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
- [x] My changes generate no new console errors locally
- [ ] If applicable, try to include a test that fails without this PR but passes with it

### Does this introduce any non-backwards compatible changes?

- [ ] Yes
- [x] No

### Does this include any user config changes?

- [ ] Yes
- [x] No
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56224a57-ec58-4186-ba62-3638655bbb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56224a57-ec58-4186-ba62-3638655bbb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

