### PR TITLE
chore: auto-fetch Cursor cloud agent transcripts on URL paste

### DIFF
--- a/.cursor/rules/cursor-cloud-agent-url.mdc
+++ b/.cursor/rules/cursor-cloud-agent-url.mdc
@@ -1,0 +1,20 @@
+---
+description: When the user pastes a Cursor cloud agents URL or bc- agent id, fetch the linked run conversation via @cursor/sdk.
+alwaysApply: true
+---
+
+# Cursor cloud agent URL → transcript fetch
+
+When the user’s message includes a **Cursor cloud agents** URL (`cursor.com/agents` with query params such as `selectedBcId`, or any **`bc-`…** cloud agent id as defined by `@cursor/sdk` cloud routing), **before** answering questions that depend on that agent’s thread:
+
+1. From the repository root, run:
+
+   `pnpm run cursor:fetch-cloud-agent -- "<full pasted URL or text containing bc-…>"`
+
+   Optional: if the paste includes a specific **`run-`…** id, append `--run run-…` so that run is fetched instead of the latest.
+
+2. Use `CURSOR_API_KEY` from the environment (required). If the command fails, say so and do not invent transcript content.
+
+3. Parse the JSON on stdout. Keys: `agent` (metadata), `run` (id, status, timing, git), `conversation` (full `run.conversation()` turns). Prefer this payload over `Agent.messages.list`, which may be empty for some cloud agents.
+
+4. Answer using the fetched `conversation` (and `agent` / `run` context). If the user only shared a URL with no follow-up question, summarize the latest run briefly and offer to go deeper.

--- a/.cursor/rules/cursor-cloud-agent-url.mdc
+++ b/.cursor/rules/cursor-cloud-agent-url.mdc
@@ -15,6 +15,6 @@ When the user’s message includes a **Cursor cloud agents** URL (`cursor.com/ag
 
 2. Use `CURSOR_API_KEY` from the environment (required). If the command fails, say so and do not invent transcript content.
 
-3. Parse the JSON on stdout. Keys: `agent` (metadata), `run` (id, status, timing, git), `conversation` (full `run.conversation()` turns). Prefer this payload over `Agent.messages.list`, which may be empty for some cloud agents.
+3. Parse the JSON on stdout. Top-level keys: `agentId` (bc-… string), `agent` (full agent from `Agent.get`), `run` (slim object: `id`, `agentId`, `status`, `createdAt`, `durationMs`, `git`), `conversation` (full `run.conversation()` turns). Prefer this payload over `Agent.messages.list`, which may be empty for some cloud agents.
 
 4. Answer using the fetched `conversation` (and `agent` / `run` context). If the user only shared a URL with no follow-up question, summarize the latest run briefly and offer to go deeper.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:vitest": "pnpm --filter @flatbread/codegen --filter @flatbread/utils test",
     "test": "pnpm build && pnpm test:ava && pnpm test:vitest",
     "verify": "pnpm lint && pnpm typecheck && pnpm build && pnpm test",
+    "cursor:fetch-cloud-agent": "pnpm --filter @flatbread/proof exec node scripts/fetch-cloud-agent-conversation.mjs",
     "dev:test": "ava --watch --verbose",
     "prepare": "husky install"
   },

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -35,6 +35,7 @@
     "bin",
     "dist",
     "src",
+    "scripts",
     "*.d.ts"
   ],
   "engines": {

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -7,7 +7,8 @@
     "build": "tsup",
     "dev": "tsup --watch src",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "models:list": "tsx src/list_models.ts"
+    "models:list": "tsx src/list_models.ts",
+    "cursor:fetch-cloud-agent": "node scripts/fetch-cloud-agent-conversation.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
+++ b/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Fetch a Cursor cloud agent run transcript via @cursor/sdk.
+ * Usage: node scripts/fetch-cloud-agent-conversation.mjs "<url-or-text>" [--run run-uuid]
+ * Env: CURSOR_API_KEY (optional explicit key: --api-key …, not recommended for shell history)
+ */
+import { Agent } from '@cursor/sdk';
+
+const BC_RE = /\bbc-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+const RUN_RE = /\brun-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+
+function parseArgs(argv) {
+  const positional = [];
+  let explicitRun;
+  let apiKey;
+  const args = argv.filter((a) => a !== '--');
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--run' && args[i + 1]) {
+      explicitRun = args[++i];
+      continue;
+    }
+    if (a === '--api-key' && args[i + 1]) {
+      apiKey = args[++i];
+      continue;
+    }
+    if (a.startsWith('-')) {
+      console.error(`Unknown flag: ${a}`);
+      process.exit(1);
+    }
+    positional.push(a);
+  }
+  return { input: positional.join(' ').trim(), explicitRun, apiKey };
+}
+
+function extractFromUrl(raw) {
+  const trimmed = raw.trim();
+  let agentId;
+  let runId;
+  try {
+    const href = /^https?:\/\//i.test(trimmed)
+      ? trimmed
+      : trimmed.includes('cursor.com')
+        ? `https://${trimmed.replace(/^\/+/, '')}`
+        : null;
+    if (href) {
+      const u = new URL(href);
+      const keysAgent = [
+        'selectedBcId',
+        'agentId',
+        'bcId',
+        'id',
+        'agent',
+      ];
+      for (const k of keysAgent) {
+        const v = u.searchParams.get(k);
+        if (v && BC_RE.test(v)) {
+          agentId = v.match(BC_RE)[0];
+          break;
+        }
+      }
+      const keysRun = ['selectedRunId', 'runId', 'run'];
+      for (const k of keysRun) {
+        const v = u.searchParams.get(k);
+        if (v && RUN_RE.test(v)) {
+          runId = v.match(RUN_RE)[0];
+          break;
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+  if (!agentId) {
+    const m = trimmed.match(BC_RE);
+    if (m) agentId = m[0];
+  }
+  if (!runId) {
+    const m = trimmed.match(RUN_RE);
+    if (m) runId = m[0];
+  }
+  return { agentId, runId };
+}
+
+async function main() {
+  const { input, explicitRun, apiKey } = parseArgs(
+    process.argv.slice(2).filter((a) => a !== '--'),
+  );
+  let raw = input;
+  if (input === '' || input === '-') {
+    const { readFile } = await import('node:fs/promises');
+    raw = String(await readFile(0, 'utf8')).trim();
+  }
+
+  if (!process.env.CURSOR_API_KEY && !apiKey) {
+    console.error(
+      'Missing CURSOR_API_KEY (or pass --api-key for one-off use).',
+    );
+    process.exit(1);
+  }
+
+  if (!raw) {
+    console.error(
+      'Usage: node scripts/fetch-cloud-agent-conversation.mjs "<cursor agents url or bc- id>" [--run run-uuid]',
+    );
+    process.exit(1);
+  }
+
+  const { agentId, runId: runFromText } = extractFromUrl(raw);
+  if (!agentId) {
+    console.error(
+      'Could not find a cloud agent id (bc-…). Paste a cursor.com/agents URL or the bc-… id.',
+    );
+    process.exit(1);
+  }
+
+  const opts = apiKey ? { apiKey } : {};
+
+  const agent = await Agent.get(agentId, opts);
+  const runId = explicitRun ?? runFromText;
+
+  let run;
+  if (runId) {
+    run = await Agent.getRun(runId, {
+      runtime: 'cloud',
+      agentId,
+      ...opts,
+    });
+  } else {
+    const { items } = await Agent.listRuns(agentId, {
+      runtime: 'cloud',
+      limit: 30,
+      ...opts,
+    });
+    if (!items.length) {
+      console.error(`No runs found for agent ${agentId}.`);
+      process.exit(1);
+    }
+    const sorted = [...items].sort(
+      (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
+    );
+    run = sorted[0];
+  }
+
+  const conversation = await run.conversation();
+  const out = {
+    agentId,
+    agent,
+    run: {
+      id: run.id,
+      agentId: run.agentId,
+      status: run.status,
+      createdAt: run.createdAt,
+      durationMs: run.durationMs,
+      git: run.git,
+    },
+    conversation,
+  };
+  process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+}
+
+main().catch((e) => {
+  console.error(e?.message || e);
+  process.exit(1);
+});

--- a/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
+++ b/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
@@ -26,6 +26,10 @@ function parseArgs(argv) {
       apiKey = args[++i];
       continue;
     }
+    if (a === '-') {
+      positional.push(a);
+      continue;
+    }
     if (a.startsWith('-')) {
       console.error(`Unknown flag: ${a}`);
       process.exit(1);
@@ -33,6 +37,15 @@ function parseArgs(argv) {
     positional.push(a);
   }
   return { input: positional.join(' ').trim(), explicitRun, apiKey };
+}
+
+/** Read until stdin EOF (non-blocking when stdin is already closed with no data). */
+async function readStdinUtf8() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8');
 }
 
 function extractFromUrl(raw) {
@@ -83,9 +96,13 @@ async function main() {
     process.argv.slice(2).filter((a) => a !== '--')
   );
   let raw = input;
-  if (input === '' || input === '-') {
-    const { readFile } = await import('node:fs/promises');
-    raw = String(await readFile(0, 'utf8')).trim();
+  if (input === '-') {
+    raw = (await readStdinUtf8()).trim();
+  } else if (input === '') {
+    // Avoid blocking on an interactive TTY when no URL argument was given.
+    if (!process.stdin.isTTY) {
+      raw = (await readStdinUtf8()).trim();
+    }
   }
 
   if (!process.env.CURSOR_API_KEY && !apiKey) {

--- a/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
+++ b/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
@@ -18,12 +18,28 @@ function parseArgs(argv) {
   const args = argv.filter((a) => a !== '--');
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === '--run' && args[i + 1]) {
-      explicitRun = args[++i];
+    if (a === '--run') {
+      const v = args[i + 1];
+      if (!v || v.startsWith('-')) {
+        console.error(
+          'Missing value for --run (expected run-… uuid after the flag).'
+        );
+        process.exit(1);
+      }
+      explicitRun = v;
+      i++;
       continue;
     }
-    if (a === '--api-key' && args[i + 1]) {
-      apiKey = args[++i];
+    if (a === '--api-key') {
+      const v = args[i + 1];
+      if (!v || v.startsWith('-')) {
+        console.error(
+          'Missing value for --api-key (expected the key after the flag).'
+        );
+        process.exit(1);
+      }
+      apiKey = v;
+      i++;
       continue;
     }
     if (a === '-') {
@@ -52,14 +68,19 @@ function extractFromUrl(raw) {
   const trimmed = raw.trim();
   let agentId;
   let runId;
-  try {
-    const href = /^https?:\/\//i.test(trimmed)
-      ? trimmed
-      : trimmed.includes('cursor.com')
-      ? `https://${trimmed.replace(/^\/+/, '')}`
-      : null;
-    if (href) {
-      const u = new URL(href);
+  const href = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : trimmed.includes('cursor.com')
+    ? `https://${trimmed.replace(/^\/+/, '')}`
+    : null;
+  if (href) {
+    let u;
+    try {
+      u = new URL(href);
+    } catch {
+      u = undefined;
+    }
+    if (u) {
       const keysAgent = ['selectedBcId', 'agentId', 'bcId', 'id', 'agent'];
       for (const k of keysAgent) {
         const v = u.searchParams.get(k);
@@ -77,8 +98,6 @@ function extractFromUrl(raw) {
         }
       }
     }
-  } catch {
-    // ignore
   }
   if (!agentId) {
     const m = trimmed.match(BC_RE);
@@ -92,9 +111,7 @@ function extractFromUrl(raw) {
 }
 
 async function main() {
-  const { input, explicitRun, apiKey } = parseArgs(
-    process.argv.slice(2).filter((a) => a !== '--')
-  );
+  const { input, explicitRun, apiKey } = parseArgs(process.argv.slice(2));
   let raw = input;
   if (input === '-') {
     raw = (await readStdinUtf8()).trim();
@@ -114,7 +131,7 @@ async function main() {
 
   if (!raw) {
     console.error(
-      'Usage: node scripts/fetch-cloud-agent-conversation.mjs "<cursor agents url or bc- id>" [--run run-uuid]'
+      'Usage: node scripts/fetch-cloud-agent-conversation.mjs "<cursor agents url or bc- id>" [--run run-uuid] [--api-key …]'
     );
     process.exit(1);
   }
@@ -149,9 +166,12 @@ async function main() {
       console.error(`No runs found for agent ${agentId}.`);
       process.exit(1);
     }
-    const sorted = [...items].sort(
-      (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0)
-    );
+    const sorted = [...items].sort((a, b) => {
+      const tb = b.createdAt ?? Number.NEGATIVE_INFINITY;
+      const ta = a.createdAt ?? Number.NEGATIVE_INFINITY;
+      if (tb !== ta) return tb - ta;
+      return String(b.id ?? '').localeCompare(String(a.id ?? ''));
+    });
     run = sorted[0];
   }
 
@@ -173,6 +193,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  console.error(e?.message || e);
+  console.error(e);
   process.exit(1);
 });

--- a/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
+++ b/packages/proof/scripts/fetch-cloud-agent-conversation.mjs
@@ -6,8 +6,10 @@
  */
 import { Agent } from '@cursor/sdk';
 
-const BC_RE = /\bbc-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
-const RUN_RE = /\brun-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+const BC_RE =
+  /\bbc-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+const RUN_RE =
+  /\brun-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
 
 function parseArgs(argv) {
   const positional = [];
@@ -41,17 +43,11 @@ function extractFromUrl(raw) {
     const href = /^https?:\/\//i.test(trimmed)
       ? trimmed
       : trimmed.includes('cursor.com')
-        ? `https://${trimmed.replace(/^\/+/, '')}`
-        : null;
+      ? `https://${trimmed.replace(/^\/+/, '')}`
+      : null;
     if (href) {
       const u = new URL(href);
-      const keysAgent = [
-        'selectedBcId',
-        'agentId',
-        'bcId',
-        'id',
-        'agent',
-      ];
+      const keysAgent = ['selectedBcId', 'agentId', 'bcId', 'id', 'agent'];
       for (const k of keysAgent) {
         const v = u.searchParams.get(k);
         if (v && BC_RE.test(v)) {
@@ -84,7 +80,7 @@ function extractFromUrl(raw) {
 
 async function main() {
   const { input, explicitRun, apiKey } = parseArgs(
-    process.argv.slice(2).filter((a) => a !== '--'),
+    process.argv.slice(2).filter((a) => a !== '--')
   );
   let raw = input;
   if (input === '' || input === '-') {
@@ -94,14 +90,14 @@ async function main() {
 
   if (!process.env.CURSOR_API_KEY && !apiKey) {
     console.error(
-      'Missing CURSOR_API_KEY (or pass --api-key for one-off use).',
+      'Missing CURSOR_API_KEY (or pass --api-key for one-off use).'
     );
     process.exit(1);
   }
 
   if (!raw) {
     console.error(
-      'Usage: node scripts/fetch-cloud-agent-conversation.mjs "<cursor agents url or bc- id>" [--run run-uuid]',
+      'Usage: node scripts/fetch-cloud-agent-conversation.mjs "<cursor agents url or bc- id>" [--run run-uuid]'
     );
     process.exit(1);
   }
@@ -109,7 +105,7 @@ async function main() {
   const { agentId, runId: runFromText } = extractFromUrl(raw);
   if (!agentId) {
     console.error(
-      'Could not find a cloud agent id (bc-…). Paste a cursor.com/agents URL or the bc-… id.',
+      'Could not find a cloud agent id (bc-…). Paste a cursor.com/agents URL or the bc-… id.'
     );
     process.exit(1);
   }
@@ -137,7 +133,7 @@ async function main() {
       process.exit(1);
     }
     const sorted = [...items].sort(
-      (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
+      (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0)
     );
     run = sorted[0];
   }

--- a/packages/proof/scripts/fetch-cloud-agent-conversation.test.js
+++ b/packages/proof/scripts/fetch-cloud-agent-conversation.test.js
@@ -38,6 +38,23 @@ test('no positional args: piped stdin is read; then missing API key (not readFil
   t.notRegex(stderr, /Received type number/, stderr);
 });
 
+test('--run without value exits before unknown-flag / API key', async (t) => {
+  const { code, stderr } = await runScript(['--run'], '');
+  t.is(code, 1);
+  t.true(
+    stderr.includes('Missing value for --run') || stderr.includes('--run'),
+    stderr
+  );
+  t.false(stderr.startsWith('Unknown flag'), stderr);
+});
+
+test('--api-key without value exits before unknown-flag', async (t) => {
+  const { code, stderr } = await runScript(['--api-key'], '');
+  t.is(code, 1);
+  t.true(stderr.includes('--api-key'), stderr);
+  t.false(stderr.startsWith('Unknown flag'), stderr);
+});
+
 test('dash positional: piped stdin is read; then missing API key', async (t) => {
   const bc = 'bc-aaaaaaaa-bbbb-cccc-dddddddddddd';
   const { code, stderr } = await runScript(['-'], bc);

--- a/packages/proof/scripts/fetch-cloud-agent-conversation.test.js
+++ b/packages/proof/scripts/fetch-cloud-agent-conversation.test.js
@@ -1,0 +1,48 @@
+import test from 'ava';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const script = path.join(__dirname, 'fetch-cloud-agent-conversation.mjs');
+
+function envWithoutCursorApiKey(extra = {}) {
+  const env = { ...process.env, ...extra };
+  delete env.CURSOR_API_KEY;
+  return env;
+}
+
+function runScript(args, stdinText, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [script, ...args], {
+      env: envWithoutCursorApiKey(extraEnv),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stderr }));
+    child.stdin.end(stdinText);
+  });
+}
+
+test('no positional args: piped stdin is read; then missing API key (not readFile fd error)', async (t) => {
+  const bc = 'bc-aaaaaaaa-bbbb-cccc-dddddddddddd';
+  const { code, stderr } = await runScript([], `${bc}\n`);
+  t.is(code, 1);
+  t.true(stderr.includes('CURSOR_API_KEY'), stderr);
+  t.notRegex(stderr, /must be of type string/, stderr);
+  t.notRegex(stderr, /Received type number/, stderr);
+});
+
+test('dash positional: piped stdin is read; then missing API key', async (t) => {
+  const bc = 'bc-aaaaaaaa-bbbb-cccc-dddddddddddd';
+  const { code, stderr } = await runScript(['-'], bc);
+  t.is(code, 1);
+  t.true(stderr.includes('CURSOR_API_KEY'), stderr);
+  t.notRegex(stderr, /must be of type string/, stderr);
+  t.notRegex(stderr, /Received type number/, stderr);
+});


### PR DESCRIPTION
Add a workspace Cursor rule and a pnpm script that call @cursor/sdk (Agent.listRuns + getRun + conversation) when a cursor.com/agents URL or bc- agent id appears in chat.