### PR TITLE
Drafts: OpenAI Open Source Fund + Claude for OSS applications, plus funding-program landscape

### DIFF
--- a/funding-applications/REVIEW-CHECKLIST.md
+++ b/funding-applications/REVIEW-CHECKLIST.md
@@ -1,0 +1,107 @@
+# Pre-submission review — Flatbread funding drafts
+
+Unified checklist for `openai-open-source-fund.md` and `claude-for-oss-brief.md` before submission.
+
+---
+
+## 1. Acceptance-likelihood self-assessment
+
+Scores are **1–5** (1 = weak, 5 = strong). Interpret as an internal sanity check, not a prediction.
+
+### OpenAI Open Source Fund (`openai-open-source-fund.md`)
+
+| Dimension | Score | Notes |
+|-----------|-------|--------|
+| Clarity | 4 | Structure mirrors the form; thesis → use of credits → budget → roadmap → public commitment reads linearly. Some density in the opening “brief description” may fatigue a skimmer. |
+| Technical specificity | 5 | Named packages, paths (`packages/proof`), CI file, concrete credit line items, quarterly milestones with verifiable deliverables. |
+| Funder-fit | 5 | Explicit Codex CLI / PR / release automation / dog-food `@flatbread/proof` loop matches what the program is positioned to amplify. |
+| Evidence of traction | 3–4 | Strong *technical* artifact (`@flatbread/proof`) and internal process proof; weaker on classic signals (stars, downloads, adopters named). Co-maintainer caveat is flagged honestly — good ethics, slight risk if read as solo bus factor. |
+| Maintainer credibility | 4 | Clear role attribution; npm/package ownership cited; avoids anonymous “we.” LinkedIn/GitHub placeholders still sap completeness until filled. |
+| Ask rationale | 5 | Credits map to enumerated workflows; budget table totals the published cap; optional cash fork is disciplined. |
+
+**Overall verdict:** The OpenAI draft is **submission-ready in substance** once identity/org fields are verified. Its main vulnerability is reliance on narrative traction (memos + shipped proof) rather than community scale; compensating angles — Codex-shaped automation and a credible 12‑month throughput plan — are well aligned with the likely reviewer mental model.
+
+### Claude for Open Source (`claude-for-oss-brief.md`)
+
+| Dimension | Score | Notes |
+|-----------|-------|--------|
+| Clarity | 4 | Sales-brief shape is appropriate; eligibility table helps a human reviewer triage quickly. Token math is dense — may need a one-line “bottom line” up front. |
+| Technical specificity | 4–5 | Proof package, MCP/eval harness, provider plan, and fixture-scale assumptions are concrete. Roadmap item 4 vs OpenAI’s `flatbread-mcp` naming should be reconciled (see §4). |
+| Funder-fit | 4–5 | MCP + Claude Code + Skills + “neutral plumbing” tracks Anthropic messaging; Impact track framing hedges star/download gaps responsibly. |
+| Evidence of traction | 3–4 | Same profile as OpenAI: strong engineering evidence, lighter on ecosystem metrics. “Recent activity” leans on audit dating — ensure repo activity actually supports that claim at submit time. |
+| Maintainer credibility | 4 | Consistent with OpenAI draft; “sole maintainer” is explicit — double-edged for funders sensitive to sustainability. |
+| Ask rationale | 3–4 | Max seat ask is clear; **API credits** are positioned as valuable but flagged UNVERIFIED — if credits are out of scope, the brief should still stand on the seat value alone (tighten that branch). |
+
+**Overall verdict:** The Claude brief is **strong on fit and technical story** but **more sensitive to program mechanics** (single grant shape, form fields, eligibility wording). Tighten the ask when API credits are not in play, resolve the hard timeline sentence against live program terms, and align MCP package naming with the OpenAI draft to avoid “two different products” confusion.
+
+---
+
+## 2. Open UNVERIFIED items the user MUST resolve before submission
+
+Consolidated from both files and cross-cutting checks:
+
+- **LinkedIn:** Canonical URL for Tony Ketcham (OpenAI form).
+- **Primary GitHub handle:** Confirm the account with **write/owner** access on `FlatbreadLabs` (OpenAI lists `toeknee-FlatbreadLabs`; Claude references `package.json` — ensure they match reality and the form).
+- **Email:** Confirm `ketcham.dev@gmail.com` is the address you want on file vs any GitHub noreply preference (OpenAI note).
+- **OpenAI Org ID:** Whether the live form includes this field; paste if required (OpenAI).
+- **Cash component:** Whether OpenAI’s live form offers cash in addition to credits; if yes, whether to add the **$15,000** maintainer-time line (OpenAI).
+- **Seat redistribution:** Whether ChatGPT Pro / Codex seats may be offered to **non-maintainer** contributors before committing the “top 2 contributors” line (OpenAI budget).
+- **Co-maintainers:** Final honest list (sole vs multiple) for OpenAI; aligns with Claude’s “1 seat, up to 2 if co-maintainer lands.”
+- **Claude program shape:** Confirm whether the offer is **only** a 6‑month Max seat or also **separate API credits** (Claude).
+- **Claude eligibility language:** Official rules on OSI license, commercial use, and star/download thresholds — playbook items were inferred; verify against current Anthropic copy (Claude).
+- **Claude intake form fields:** Map the brief’s “Form responses” section to the **actual** contact-sales form (Claude).
+- **Claude timeline cap:** The brief ties an end boundary to a specific calendar date — verify against the live offer’s grant window and remove or rephrase if wrong (Claude).
+- **Budget arithmetic / cap rules:** Confirm OpenAI allows the **stated split** (e.g., contributor sponsorship line mixing credits + seats) under program terms.
+- **Repo activity at submit time:** Both drafts imply recent releases/CI/commits — sanity-check GitHub/npm so claims stay true on the submission clock.
+
+---
+
+## 3. Suggested edits to strengthen each draft
+
+### `openai-open-source-fund.md`
+
+- **`Brief description of the project` (≈L44–50):** Lead with **one sentence** on problem + Effort Graph, then the README verbatim quote. Reduces burying the pivot below stylistic flourish.
+- **`Which open source project` (≈L42):** Optionally add **one npm download or release cadence fact** if you have a truthful number — starves the “traction” objection without fluff.
+- **`How would you use API credits` (≈L63–71):** Add a **single closing sentence** estimating relative credit burn (e.g., PR automation vs eval harness vs proof DAGs) so reviewers see prioritization under a $25k cap.
+- **`Contributor sponsorship` row (budget table ≈L102):** Until seat redistribution is confirmed, soften to **“if permitted”** in the visible submission text or move seats to an internal appendix — the reviewer note alone may not propagate to the pasted form fields.
+- **`Anything else` (≈L73–80):** The “Codex adapter is straightforward” line could read as hand-wavy — add **half a sentence** on interface surface (same DAG graph, swap provider/SDK) if accurate.
+- **§5 citation (≈L150):** Replace or supplement `§5` with a **heading string** (`README` / doc title) so copy-paste into a plain-text form doesn’t lose meaning.
+
+### `claude-for-oss-brief.md`
+
+- **`What we'd use Claude for` (≈L37–40):** Open with **“Primary ask: Claude Max seat for maintainer loops; secondary (if eligible): API tokens for nightly evals.”** Then the token math — improves scanability if credits are marginal.
+- **Token projection paragraph:** Flag **confidence** (low/medium) or peg one number as **upper bound** to avoid seeming over-precise without data.
+- **Roadmap items 4 vs 9 (≈L59–65):** Deduplicate overlap between “MCP server” and “docs + Skills examples” — one bullet can own integration docs.
+- **`Form responses` / Timeline (≈L82–83):** Replace the **fixed end date** with “within the approved grant window from start” unless the program publishes that exact boundary; mirror whatever the live FAQ says.
+- **`packages/flatbread` (≈L35, L59):** If the MCP server package name is **`flatbread-mcp`** (per OpenAI draft), align the path **or** add “(package name TBD)” once — reviewers should not see conflicting locations.
+- **Eligibility table row “sole author/maintainer”:** If contributors have merge rights, rephrase to **“primary maintainer / release owner”** to stay defensible against `git shortlog`.
+
+---
+
+## 4. Cross-draft consistency check
+
+| Element | OpenAI draft | Claude draft | Reconciles? |
+|---------|---------------|--------------|-------------|
+| Elevator pitch / README quote | Verbatim README line embedded in narrative | Same quote | **Yes** |
+| License | MIT (frontmatter + body) | MIT | **Yes** |
+| Maintainer | Tony Ketcham, primary/sole framing | Tony Ketcham | **Yes** (OpenAI leaves room for co-maintainers — ensure both drafts match final reality) |
+| Repo URL | `https://github.com/FlatbreadLabs/flatbread` | Same | **Yes** |
+| `@flatbread/proof` thesis | Cursor-SDK DAG; Codex adapter on roadmap | Cursor-SDK DAG; Claude provider on roadmap | **Yes** |
+| MCP server | `flatbread-mcp`, Q3 MVP | MCP in **`packages/flatbread`** | **Drift** — align naming/path |
+| Roadmap pillars | Typed config, ID norm, validation, watch, MCP, Effort Graph, evals, docs, v1.0 | Same themes + generated TS adapter, eval dashboard explicit | **Mostly aligned** — Claude adds items OpenAI folds into Q4; optional one-line cross-reference in OpenAI to “generated TS adapter” |
+| Funding ask | $25k API credits + bundled seats (+ optional cash) | ~$1.2k equivalent Max seat ± API credits | **Intentionally different programs** — no conflict; verify Claude brief does not implicitly promise API funding |
+| Sole maintainer vs community | Slack + contributors; wary of padded co-maintainer list | “1 seat; up to 2 if co-maintainer” | **Minor tension** — pick one staffing story for external readers |
+| Public outputs | Discussions, Slack, quarterly blog, `funding-research/` evals | Case studies, MCP guide for Claude Code, eval dashboard, talk | **Aligned in spirit**; different platforms — acceptable |
+| Sensitive identity fields | Email + GitHub + LinkedIn in draft | Maintainer handle deferred to `package.json` | **Drift risk** — ensure Claude intake gets the **same** GitHub identity OpenAI submits |
+
+---
+
+## 5. Recommended submission order and timing
+
+**Recommend submitting the OpenAI application first.**
+
+**Reasoning (no calendar dates):** The OpenAI draft is **longer and form-anchored**, with several **blocking field verifications** (LinkedIn, org handle, optional org ID, seat redistribution). Getting those verified once tends to stabilize the **canonical maintainer/GitHub/contact story** that the Claude intake will likely re-use. Strategically, OpenAI emphasizes **Codex-native automation** tied to `@flatbread/proof`; Anthropic emphasizes **Claude Max + MCP neutrality**. Sending OpenAI after you freeze those technical claims reduces the odds of rewriting the Claude brief twice. If program windows or deadlines diverge, **prioritize whichever portal has the tighter cutoff** once you know actual terms — otherwise default to OpenAI first, Claude second after a quick **cross-draft pass** on MCP naming, maintainer/consistency wording, and removal of any date-bound language not confirmed by Anthropic.
+
+---
+
+*Checklist generated for internal review — update both drafts before pasting into live forms.*

--- a/funding-applications/REVIEW-CHECKLIST.md
+++ b/funding-applications/REVIEW-CHECKLIST.md
@@ -4,6 +4,17 @@ Unified checklist for `openai-open-source-fund.md` and `claude-for-oss-brief.md`
 
 ---
 
+## Revision summary — roadmap compression + audacious bets
+
+- **Foundation window (months 1–4):** Both drafts compress typed config, ID normalization, relation validation, watch-mode parity, and the Effort Graph MVP (Conventions preset, Append API, `flatbread-mcp`) into Phases 1–2 — no quarter-by-quarter spread; the back half is free for higher-risk deliverables.
+- **Audacious bets (months 5–12):** **A** — six named workflow presets + 7th community slot; **B** — HITL ergonomics (`needsApproval`, plan-review gate, LangGraph-style pause/resume on `thread_id`); **C** — continuous evals (`fixture-promote`, PR regression replay, public Inspect-View-style dashboard, eval-driven preset retuning). OpenAI funds these primarily with API credits; Claude frames them as Max-seat + optional API workloads on `@flatbread/proof`.
+- **Budget (OpenAI):** Rebalanced toward **Phase 3 presets ($8k)**, **HITL ($3.5k)**, and **evals loop ($5k)**; foundation and Effort Graph + MCP lines are deliberately smaller vs the old shape. Cash NOTE (if offered) targets presets + HITL surfaces.
+- **Claude token projection:** Raised to ~**80–160M input / ~16–32M output** tokens/month (~**2–3×** prior estimate), with arithmetic tied to continuous preset DAGs + nightly fixture replay — signals continuous harness cost, not ad-hoc IDE use.
+- **Explicit narrative wedge:** Both drafts now name **use-case coverage**, **community adoption**, and **workflow capture** as the public payoff; OpenAI anchors **Codex** as the harness bet; Claude keeps **MCP neutrality + Claude Code / HITL / evals** alignment.
+- **Cross-draft alignment:** Same **four-phase roadmap**, identical **six preset names** (+ community slot), shared **Bet A / B / C** vocabulary — reviewers can diff programs without conflicting technical claims.
+
+---
+
 ## 1. Acceptance-likelihood self-assessment
 
 Scores are **1–5** (1 = weak, 5 = strong). Interpret as an internal sanity check, not a prediction.
@@ -12,69 +23,69 @@ Scores are **1–5** (1 = weak, 5 = strong). Interpret as an internal sanity che
 
 | Dimension | Score | Notes |
 |-----------|-------|--------|
-| Clarity | 4 | Structure mirrors the form; thesis → use of credits → budget → roadmap → public commitment reads linearly. Some density in the opening “brief description” may fatigue a skimmer. |
-| Technical specificity | 5 | Named packages, paths (`packages/proof`), CI file, concrete credit line items, quarterly milestones with verifiable deliverables. |
-| Funder-fit | 5 | Explicit Codex CLI / PR / release automation / dog-food `@flatbread/proof` loop matches what the program is positioned to amplify. |
-| Evidence of traction | 3–4 | Strong *technical* artifact (`@flatbread/proof`) and internal process proof; weaker on classic signals (stars, downloads, adopters named). Co-maintainer caveat is flagged honestly — good ethics, slight risk if read as solo bus factor. |
-| Maintainer credibility | 4 | Clear role attribution; npm/package ownership cited; avoids anonymous “we.” LinkedIn/GitHub placeholders still sap completeness until filled. |
-| Ask rationale | 5 | Credits map to enumerated workflows; budget table totals the published cap; optional cash fork is disciplined. |
+| Clarity | 3–4 | Form order is intact; audacious sections are **information-dense** (7 credit bullets + full Phase 3/4 text). Skimmers may miss the forest — an exec summary sentence at the top of “How would you use credits” would help. |
+| Technical specificity | **5** | **Raised:** Six presets with sizing math (~nodes × runs × tokens), HITL and eval sub-bullets, budget lines tied to Phase 3/4. Reviewers get concrete hooks for due diligence. |
+| Funder-fit | 5 | Codex PR/release automation, dog-food `@flatbread/proof`, “betting on Codex specifically” — tightly on-message for a Codex-oriented fund. |
+| Evidence of traction | **2–3** | **Due-diligence cost raised:** Same strong engineering proof, but **scope vs solo maintainer** is starker (preset catalog + HITL product + public evals). Reviewers may ask “who ships this if Tony is unavailable?” — co-maintainer honesty is good; **mitigation** (phased cuts, community slot) is implied but not spelled as risk table. |
+| Maintainer credibility | 4 | PMF audit + opportunity memo + shipped `proof` still land; placeholders (LinkedIn, exact handle) unchanged. |
+| Ask rationale | **5** | **Raised:** Six-row budget maps dollars to Bets A/B/C; optional cash NOTE points at the audacious surface area. |
 
-**Overall verdict:** The OpenAI draft is **submission-ready in substance** once identity/org fields are verified. Its main vulnerability is reliance on narrative traction (memos + shipped proof) rather than community scale; compensating angles — Codex-shaped automation and a credible 12‑month throughput plan — are well aligned with the likely reviewer mental model.
+**Overall verdict:** **Stronger on specificity and ask–roadmap alignment** than the pre-revision draft; **main new risk is ambition density** (reviewer asks “is this one year for one person?”). Worth one explicit sentence on **sequencing / minimum viable catalog** if a funder pushes back.
 
 ### Claude for Open Source (`claude-for-oss-brief.md`)
 
 | Dimension | Score | Notes |
 |-----------|-------|--------|
-| Clarity | 4 | Sales-brief shape is appropriate; eligibility table helps a human reviewer triage quickly. Token math is dense — may need a one-line “bottom line” up front. |
-| Technical specificity | 4–5 | Proof package, MCP/eval harness, provider plan, and fixture-scale assumptions are concrete. Roadmap item 4 vs OpenAI’s `flatbread-mcp` naming should be reconciled (see §4). |
-| Funder-fit | 4–5 | MCP + Claude Code + Skills + “neutral plumbing” tracks Anthropic messaging; Impact track framing hedges star/download gaps responsibly. |
-| Evidence of traction | 3–4 | Same profile as OpenAI: strong engineering evidence, lighter on ecosystem metrics. “Recent activity” leans on audit dating — ensure repo activity actually supports that claim at submit time. |
-| Maintainer credibility | 4 | Consistent with OpenAI draft; “sole maintainer” is explicit — double-edged for funders sensitive to sustainability. |
-| Ask rationale | 3–4 | Max seat ask is clear; **API credits** are positioned as valuable but flagged UNVERIFIED — if credits are out of scope, the brief should still stand on the seat value alone (tighten that branch). |
+| Clarity | 4 | Brief length is capped; four phases scan well. Token paragraph remains the heaviest block — a one-line “request: Max + (if eligible) API for harness” up front still helps. |
+| Technical specificity | **5** | **Raised:** Phase 3 names all six presets; Phase 4 mirrors OpenAI’s HITL + eval machinery; public commitment adds dashboard + preset gallery. |
+| Funder-fit | **4–5** | MCP, Skills, HITL (`needsApproval`, plan mode), Inspect / evals-as-research — explicit bridge to Anthropic positioning. |
+| Evidence of traction | **2–3** | Same as OpenAI: engineering story > ecosystem scale. **Audacious scope** increases “solo bus factor” salience here too. |
+| Maintainer credibility | 4 | Consistent sole-maintainer framing; “up to 2 seats if co-maintainer” is still a hedge funders will notice. |
+| Ask rationale | **3** | Max seat is clear. **Due-diligence cost raised:** High token projection + “continuous eval harness” **depends on whether API credits are in-program**; if not, brief must not read as promising unfunded load. |
 
-**Overall verdict:** The Claude brief is **strong on fit and technical story** but **more sensitive to program mechanics** (single grant shape, form fields, eligibility wording). Tighten the ask when API credits are not in play, resolve the hard timeline sentence against live program terms, and align MCP package naming with the OpenAI draft to avoid “two different products” confusion.
+**Overall verdict:** **Fit and technical alignment improved**; **program-mechanics risk** (seat-only vs seat+API, form fields) and **numeric credibility** of token bounds are the top reviewer questions. Confirming **API eligibility for an automated eval loop** is now **higher priority** than generic “credits mentioned.”
 
 ---
 
 ## 2. Open UNVERIFIED items the user MUST resolve before submission
 
-Consolidated from both files and cross-cutting checks:
+Consolidated from both files and cross-cutting checks. **Removed** items that the revision pass already fixed in draft text (e.g. Q1–Q4 vs four-phase misalignment, Claude’s old hard end-date wording).
 
 - **LinkedIn:** Canonical URL for Tony Ketcham (OpenAI form).
-- **Primary GitHub handle:** Confirm the account with **write/owner** access on `FlatbreadLabs` (OpenAI lists `toeknee-FlatbreadLabs`; Claude references `package.json` — ensure they match reality and the form).
-- **Email:** Confirm `ketcham.dev@gmail.com` is the address you want on file vs any GitHub noreply preference (OpenAI note).
+- **Primary GitHub handle:** Confirm the account with **write/owner** access on `FlatbreadLabs` (OpenAI lists `toeknee-FlatbreadLabs`; align with Claude / `package.json` reality).
+- **Email:** Confirm `ketcham.dev@gmail.com` vs GitHub noreply preference (OpenAI note).
 - **OpenAI Org ID:** Whether the live form includes this field; paste if required (OpenAI).
-- **Cash component:** Whether OpenAI’s live form offers cash in addition to credits; if yes, whether to add the **$15,000** maintainer-time line (OpenAI).
-- **Seat redistribution:** Whether ChatGPT Pro / Codex seats may be offered to **non-maintainer** contributors before committing the “top 2 contributors” line (OpenAI budget).
-- **Co-maintainers:** Final honest list (sole vs multiple) for OpenAI; aligns with Claude’s “1 seat, up to 2 if co-maintainer lands.”
-- **Claude program shape:** Confirm whether the offer is **only** a 6‑month Max seat or also **separate API credits** (Claude).
-- **Claude eligibility language:** Official rules on OSI license, commercial use, and star/download thresholds — playbook items were inferred; verify against current Anthropic copy (Claude).
-- **Claude intake form fields:** Map the brief’s “Form responses” section to the **actual** contact-sales form (Claude).
-- **Claude timeline cap:** The brief ties an end boundary to a specific calendar date — verify against the live offer’s grant window and remove or rephrase if wrong (Claude).
-- **Budget arithmetic / cap rules:** Confirm OpenAI allows the **stated split** (e.g., contributor sponsorship line mixing credits + seats) under program terms.
-- **Repo activity at submit time:** Both drafts imply recent releases/CI/commits — sanity-check GitHub/npm so claims stay true on the submission clock.
+- **Cash component:** Whether OpenAI’s live form offers cash; if yes, whether to use the **$15,000** maintainer-time line tied to Phase 3 + 4 (OpenAI).
+- **Seat redistribution:** Whether ChatGPT Pro / Codex seats may go to **non-maintainers** before promising “top 2 contributors” (OpenAI budget row).
+- **Co-maintainers:** Final honest list (sole vs multiple) for OpenAI; must match Claude’s “1 seat, up to 2 if co-maintainer lands.”
+- **Claude program shape — Max vs API (expanded):** Confirm whether the offer is **only** a 6‑month Max seat or also **separate API credits**. **New:** Confirm whether credits (if any) may be applied to **automated / CI-driven eval replay and preset DAG harnesses**, not merely interactive IDE sessions — the revised brief predicates meaningful value on continuous usage.
+- **Claude eligibility language:** Official rules on OSI license, commercial use, and star/download thresholds — verify against current Anthropic copy (Claude).
+- **Claude intake form fields:** Map the brief’s “Form responses” to the **actual** contact-sales form (Claude).
+- **Budget cap / mixing rules (OpenAI):** Confirm the program allows the **six-line credit split** and any **credits + seat** wording in the docs/contributors row under published terms.
+- **Preset / eval sizing truth:** Sanity-check that **node counts, run counts, and fixture-count assumptions** behind credit and token arithmetic are directionally defensible if a reviewer asks for a spreadsheet (both drafts).
 
 ---
 
 ## 3. Suggested edits to strengthen each draft
 
+_Line-level suggestions aimed at new audacious-bet content._
+
 ### `openai-open-source-fund.md`
 
-- **`Brief description of the project` (≈L44–50):** Lead with **one sentence** on problem + Effort Graph, then the README verbatim quote. Reduces burying the pivot below stylistic flourish.
-- **`Which open source project` (≈L42):** Optionally add **one npm download or release cadence fact** if you have a truthful number — starves the “traction” objection without fluff.
-- **`How would you use API credits` (≈L63–71):** Add a **single closing sentence** estimating relative credit burn (e.g., PR automation vs eval harness vs proof DAGs) so reviewers see prioritization under a $25k cap.
-- **`Contributor sponsorship` row (budget table ≈L102):** Until seat redistribution is confirmed, soften to **“if permitted”** in the visible submission text or move seats to an internal appendix — the reviewer note alone may not propagate to the pasted form fields.
-- **`Anything else` (≈L73–80):** The “Codex adapter is straightforward” line could read as hand-wavy — add **half a sentence** on interface surface (same DAG graph, swap provider/SDK) if accurate.
-- **§5 citation (≈L150):** Replace or supplement `§5` with a **heading string** (`README` / doc title) so copy-paste into a plain-text form doesn’t lose meaning.
+- **`How would you use API credits` (seven bullets):** After bullet 7, add **one sentence** stating **credit priority order under stress** (e.g. presets + eval replay before discretionary doc polish) — audacious sections invite “what drops first?” questions.
+- **Bullet 3 (preset catalog):** Add **half a sentence** on **acceptance criteria** per preset (“green DAG + published golden trace”) so “six shipped presets” is falsifiable without new scope.
+- **Bullet 4 (HITL):** Clarify **`thread_id`** as Effort Graph field vs opaque runtime ID in one clause — reviewers bridge from LangGraph metaphor to your schema.
+- **Phase 4 / public dashboard:** Note **hosting surface** (docs site subdomain vs GitHub Pages vs minimal static) so “public dashboard” isn’t assumed to be free infra.
+- **`Anything else` para 2:** Optional **italic one-liner** on **minimum viable deliverable** if timeline slips — reduces “all or nothing” read without shrinking ambition.
+- **`Why now / why us`:** One sentence tying **solo maintainer + 12 months** to **Phase ordering** (“B/C intentionally consume fixtures produced by Phase 3 runs”) reinforces feasibility.
 
 ### `claude-for-oss-brief.md`
 
-- **`What we'd use Claude for` (≈L37–40):** Open with **“Primary ask: Claude Max seat for maintainer loops; secondary (if eligible): API tokens for nightly evals.”** Then the token math — improves scanability if credits are marginal.
-- **Token projection paragraph:** Flag **confidence** (low/medium) or peg one number as **upper bound** to avoid seeming over-precise without data.
-- **Roadmap items 4 vs 9 (≈L59–65):** Deduplicate overlap between “MCP server” and “docs + Skills examples” — one bullet can own integration docs.
-- **`Form responses` / Timeline (≈L82–83):** Replace the **fixed end date** with “within the approved grant window from start” unless the program publishes that exact boundary; mirror whatever the live FAQ says.
-- **`packages/flatbread` (≈L35, L59):** If the MCP server package name is **`flatbread-mcp`** (per OpenAI draft), align the path **or** add “(package name TBD)” once — reviewers should not see conflicting locations.
-- **Eligibility table row “sole author/maintainer”:** If contributors have merge rights, rephrase to **“primary maintainer / release owner”** to stay defensible against `git shortlog`.
+- **`What we'd use Claude for` — API bullets:** Open with **“Primary: Max seat; secondary (if permitted): API for nightly preset + fixture harness.”** Then the three audacious workloads — aligns ask with continuous token story.
+- **Token projection paragraph:** Prefix with **“(upper-band estimate; we will meter and publish actuals)”** or similar — specificity raised **verification burden**; flagging bounds reduces “false precision” risk.
+- **`Maintainer + roadmap` Phase 4:** Add **“(fixtures from Phase 3 runs feed Phase 4 eval catalog)”** — one clause syncs parallelism claim with OpenAI’s compounding narrative.
+- **`Public commitment`:** Specify **dashboard refresh cadence** (monthly vs quarterly) to match OpenAI’s “refreshed quarterly” line unless you intentionally differ.
+- **`packages/flatbread` vs `flatbread-mcp`:** In the maintainer paragraph (~L35), align **implementation path** with the roadmap package name **or** add “MCP lives in workspace package `flatbread-mcp` (authoring path TBD)” — removes residual path drift vs OpenAI.
 
 ---
 
@@ -82,17 +93,16 @@ Consolidated from both files and cross-cutting checks:
 
 | Element | OpenAI draft | Claude draft | Reconciles? |
 |---------|---------------|--------------|-------------|
-| Elevator pitch / README quote | Verbatim README line embedded in narrative | Same quote | **Yes** |
-| License | MIT (frontmatter + body) | MIT | **Yes** |
-| Maintainer | Tony Ketcham, primary/sole framing | Tony Ketcham | **Yes** (OpenAI leaves room for co-maintainers — ensure both drafts match final reality) |
-| Repo URL | `https://github.com/FlatbreadLabs/flatbread` | Same | **Yes** |
-| `@flatbread/proof` thesis | Cursor-SDK DAG; Codex adapter on roadmap | Cursor-SDK DAG; Claude provider on roadmap | **Yes** |
-| MCP server | `flatbread-mcp`, Q3 MVP | MCP in **`packages/flatbread`** | **Drift** — align naming/path |
-| Roadmap pillars | Typed config, ID norm, validation, watch, MCP, Effort Graph, evals, docs, v1.0 | Same themes + generated TS adapter, eval dashboard explicit | **Mostly aligned** — Claude adds items OpenAI folds into Q4; optional one-line cross-reference in OpenAI to “generated TS adapter” |
-| Funding ask | $25k API credits + bundled seats (+ optional cash) | ~$1.2k equivalent Max seat ± API credits | **Intentionally different programs** — no conflict; verify Claude brief does not implicitly promise API funding |
-| Sole maintainer vs community | Slack + contributors; wary of padded co-maintainer list | “1 seat; up to 2 if co-maintainer” | **Minor tension** — pick one staffing story for external readers |
-| Public outputs | Discussions, Slack, quarterly blog, `funding-research/` evals | Case studies, MCP guide for Claude Code, eval dashboard, talk | **Aligned in spirit**; different platforms — acceptable |
-| Sensitive identity fields | Email + GitHub + LinkedIn in draft | Maintainer handle deferred to `package.json` | **Drift risk** — ensure Claude intake gets the **same** GitHub identity OpenAI submits |
+| **Roadmap shape** | Four phases; months 1–4 foundation + MVP; 5–8 presets; 9–12 HITL + evals parallel | Same structure and month bands | **Yes** |
+| **Six preset names** | `schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation` | Same six + 7th community slot by month 8 | **Yes** |
+| **Audacious vocabulary** | Bets A / B / C; `needsApproval`, plan-review gate, pause/resume, `fixture-promote`, PR replay, Inspect-View-style dashboard | Same hooks; Anthropic-facing HITL/evals justification | **Yes** |
+| **Pivot framing** | **Codex** as primary harness bet; opportunity memo §5 / Posture C | **Claude Max + MCP** neutrality; Claude provider on roadmap; Codex listed as harness peer | **Intentionally complementary** — same substrate, **different sponsor hooks** |
+| Elevator / README quote | Verbatim README line | Same quote | **Yes** |
+| License / repo / maintainer | MIT; `FlatbreadLabs/flatbread`; Tony | Same | **Yes** |
+| `@flatbread/proof` | Cursor-SDK today; Codex adapter funded | Claude provider funded; Cursor-SDK DAG | **Yes** — verify both don’t imply both adapters shipped day one |
+| MCP server naming | **`flatbread-mcp`** in roadmap + budget | Roadmap:**`flatbread-mcp`**; maintainer paragraph still says authoring in **`packages/flatbread`** | **Minor drift** — clarify package path vs monorepo folder (see §3) |
+| Funding ask | $25k credits + bundles (+ optional cash) | ~$1.2k Max ± API | **Programs differ** — OK; Claude must not over-promise API |
+| Public outputs | Dashboard bullet + quarterly refresh language | Dashboard + preset gallery + MCP guide | **Aligned** — align **cadence** if you want symmetry |
 
 ---
 
@@ -100,7 +110,11 @@ Consolidated from both files and cross-cutting checks:
 
 **Recommend submitting the OpenAI application first.**
 
-**Reasoning (no calendar dates):** The OpenAI draft is **longer and form-anchored**, with several **blocking field verifications** (LinkedIn, org handle, optional org ID, seat redistribution). Getting those verified once tends to stabilize the **canonical maintainer/GitHub/contact story** that the Claude intake will likely re-use. Strategically, OpenAI emphasizes **Codex-native automation** tied to `@flatbread/proof`; Anthropic emphasizes **Claude Max + MCP neutrality**. Sending OpenAI after you freeze those technical claims reduces the odds of rewriting the Claude brief twice. If program windows or deadlines diverge, **prioritize whichever portal has the tighter cutoff** once you know actual terms — otherwise default to OpenAI first, Claude second after a quick **cross-draft pass** on MCP naming, maintainer/consistency wording, and removal of any date-bound language not confirmed by Anthropic.
+**Reasoning:** The revisions **did not weaken** “freeze canonical facts first”: OpenAI remains the **longer form-anchored draft** with **LinkedIn / GitHub / optional Org ID / seat redistribution / cash fork** blocking items. Completing verification there **still establishes the single maintainer-contact and repo story** the Claude funnel reuses.
+
+**Updated angle post-revision:** Both drafts now share the **same four-phase roadmap and preset catalog** — after OpenAI submits (or freezes), Claude needs only a **short pass** for **program-specific** wording (token bounds, API-for-harness eligibility) and **`packages/flatbread` vs `flatbread-mcp`** consistency.
+
+If **Anthropic’s window is materially shorter** than OpenAI’s, **invert order** — but keep a **same-day checklist sync** so preset names and phase boundaries don’t drift.
 
 ---
 

--- a/funding-applications/claude-for-oss-brief.md
+++ b/funding-applications/claude-for-oss-brief.md
@@ -1,0 +1,85 @@
+---
+program: Claude for Open Source
+program_url: https://claude.com/contact-sales/claude-for-oss
+applicant: Tony Ketcham
+project: Flatbread
+license: MIT
+repo_url: https://github.com/FlatbreadLabs/flatbread
+status: draft
+last_updated: 2026-05-09
+---
+
+# Flatbread — Claude for Open Source brief
+
+## Project at a glance
+- **What:** Flatbread — *eat your relational markdown data and query it, too, with GraphQL inside damn near any framework* (`README.md`). A pnpm monorepo turning `.md`/YAML on disk into a typed, relational graph for sites and, increasingly, coding agents.
+- **License:** MIT (`package.json`); published to npm; Node `>=20.19`; `packageManager` pnpm 10.33.0.
+- **Traction:** Public CI (`.github/workflows/pipeline.yml`); shipped `@flatbread/proof` Cursor-SDK DAG runner; live `examples/nextjs` and `examples/sveltekit`; written PMF audit (`flatbread-flow-pmf-audit.md`) and agent-artifact thesis (`flatbread-agent-artifact-opportunity.md`).
+- **Ask:** Per-maintainer **6-month Claude Max 20x** seat (~$200/mo, ~$1,200 grant) to power agent-loop development on `@flatbread/proof` and the forthcoming MCP surface.
+
+## Eligibility checklist
+
+| Criterion (per playbook) | Evidence | Location |
+|---|---|---|
+| Public repo, OSI-style license | MIT in `package.json` | `package.json` (root) |
+| Named maintainer with merge access | Tony Ketcham, sole author/maintainer | `package.json` author field, `CONTRIBUTING.md` |
+| Recent commit / PR / release activity (≤3 mo) | Active monorepo with published packages and PMF audit dated 2026 | repo history, `flatbread-flow-pmf-audit.md` |
+| Stars / downloads threshold *or* Impact track write-up | Below 5k★/1M dl threshold today; submitting **Impact track** narrative on agent-artifact infrastructure | `flatbread-agent-artifact-opportunity.md` |
+| Contributor onboarding | `CONTRIBUTING.md`; pnpm workspace; documented `examples/` | `CONTRIBUTING.md`, `pnpm-workspace.yaml`, `examples/` |
+| Use-cases where Claude Max adds value | DAG runner + MCP eval harness (see below) | `packages/proof/`, this brief |
+
+> NOTE TO REVIEWER: Playbook flagged "OSI-license + no commercial gatekeeping" as UNVERIFIED — only "public repo" is explicit on the intake. We meet MIT regardless. Stars/downloads thresholds are also UNVERIFIED; submitting through the Impact track is the conservative path.
+
+## What we'd use Claude for
+
+**Maintainer seats — Claude Max 20x (Claude Code + Opus/Sonnet/Haiku):** 1 seat for Tony today; up to 2 if a co-maintainer lands during the grant window. Used daily for monorepo refactors, codegen on `packages/codegen`, and authoring the MCP server in `packages/flatbread`.
+
+**Claude API — `@flatbread/proof` DAG runner + agent-eval harness:**
+- `@flatbread/proof` orchestrates Cursor-SDK subagents over a typed Effort/Plan/Decision/Artifact graph. We plan to add a Claude provider alongside the existing harness so the same DAG runs against Claude Sonnet/Opus.
+- **Projected monthly token volume:** ~30–60M input + ~6–12M output tokens/month. Reasoning: ~20 DAG runs/week × ~10 nodes/run × ~30k input tokens (effort context + plan + relevant artifacts) + ~3k output tokens, plus a nightly eval sweep of ~200 fixtures × ~25k tokens. Sonnet-weighted with selective Opus on planning nodes.
+- **MCP eval harness:** scripted runs against the MCP surface to verify reference integrity (broken `Plan→Decision` links, dangling `Artifact` refs) — adds ~5–10M tokens/month.
+
+> NOTE TO REVIEWER: The playbook reads the offer as a *single fixed 6-month Max grant*; separate API credits are UNVERIFIED. If API credits are not in scope, the harness above runs on metered API spend and the Max seat covers maintainer-loop work only. We'd accept either shape.
+
+## Why Claude specifically
+
+- **MCP ecosystem participation.** Anthropic donated MCP to the Linux Foundation's Agentic AI Foundation; Flatbread's roadmap ships an **MCP surface** so coding agents (Claude Code first) can read/write the typed Effort Graph natively. We are building *for* MCP, not bolting it on.
+- **Claude Code + Skills fit.** `@flatbread/proof` is a DAG runner for harnessed coding agents — the exact shape Claude Code Skills target. The artifact shipped today (`packages/proof`) is a concrete proof-of-concept.
+- **Safety posture via typed integrity.** Our differentiator is *reference integrity for the agent-artifact layer*: typed schemas catch broken `Plan→Decision` and `Effort→Artifact` links before they cause context drift or silent regressions in long-running agent runs. This is a complement to RSP/ASL-style guardrails at the model layer.
+- **Neutral plumbing, not a wrapper.** We're an integration layer that any harness (Claude Code, Cursor, Codex) can compose against — exactly the "neutral infrastructure" stance Anthropic has rewarded in prior recipients (Apache, PSF, MCP itself).
+
+## Maintainer + roadmap
+
+**Maintainer:** Tony Ketcham — sole author/maintainer, merge access, npm publisher. See `CONTRIBUTING.md` and `package.json` author field.
+
+**12-month roadmap (aligned to `flatbread-flow-pmf-audit.md` + Effort Graph MVP):**
+1. Typed `defineConfig` with full inference end-to-end.
+2. ID normalization + relation validation across collections.
+3. Watch mode parity with build mode for agent loops.
+4. **MCP server in `packages/flatbread`** exposing read/write of Effort/Plan/Decision/Session/Artifact/Run.
+5. **Effort Graph MVP** as a first-class collection set with reference-integrity checks.
+6. Generated TS adapter parallel to GraphQL (per PMF audit pivot).
+7. `@flatbread/proof` v1: Claude provider + multi-harness DAG runs.
+8. Eval harness: regression suite over fixture Effort Graphs.
+9. Docs site + Claude Code Skills examples.
+10. Case study: Flatbread-on-Flatbread (dogfood the Effort Graph for our own roadmap).
+
+## Public commitment
+
+- **Case studies** on running a coding-agent roadmap through `@flatbread/proof` with Claude as the model provider.
+- **MCP integration guide for Claude Code** — step-by-step on wiring the Flatbread MCP server into a Claude Code project.
+- **Eval results** — public dashboard of reference-integrity regressions caught per release, published alongside `packages/proof` runs.
+- Conference / blog talk on *git-native relational memory for coding agents*, crediting Claude for OSS.
+
+## Form responses
+
+- **Project name:** Flatbread
+- **Repo URL:** https://github.com/FlatbreadLabs/flatbread
+- **License:** MIT
+- **Primary maintainer:** Tony Ketcham (GitHub handle on file in `package.json`)
+- **Stars / downloads:** Below 5k★/1M dl thresholds — applying via **Impact track** with `flatbread-agent-artifact-opportunity.md` as the write-up.
+- **Ask:** 6-month Claude Max 20x seat for the maintainer; API credits for the DAG runner + MCP eval harness if in scope.
+- **Timeline:** Start within 2 weeks of approval; deliverables (MCP server, Claude provider in `@flatbread/proof`, public eval dashboard) within the 6-month grant window ending **June 30, 2026** if offer aligns to that cap.
+- **Why Claude:** MCP-native roadmap, Claude Code Skills fit, typed integrity layer as a safety complement.
+
+> NOTE TO REVIEWER: Exact intake form fields are UNVERIFIED — playbook lists likely fields (GitHub handle, repo URL, stars/dl, recent contributions, use-cases, Impact write-up). Adjust this section to match the actual form once accessed.

--- a/funding-applications/claude-for-oss-brief.md
+++ b/funding-applications/claude-for-oss-brief.md
@@ -12,10 +12,10 @@ last_updated: 2026-05-09
 # Flatbread — Claude for Open Source brief
 
 ## Project at a glance
-- **What:** Flatbread — *eat your relational markdown data and query it, too, with GraphQL inside damn near any framework* (`README.md`). A pnpm monorepo turning `.md`/YAML on disk into a typed, relational graph for sites and, increasingly, coding agents.
-- **License:** MIT (`package.json`); published to npm; Node `>=20.19`; `packageManager` pnpm 10.33.0.
-- **Traction:** Public CI (`.github/workflows/pipeline.yml`); shipped `@flatbread/proof` Cursor-SDK DAG runner; live `examples/nextjs` and `examples/sveltekit`; written PMF audit (`flatbread-flow-pmf-audit.md`) and agent-artifact thesis (`flatbread-agent-artifact-opportunity.md`).
-- **Ask:** Per-maintainer **6-month Claude Max 20x** seat (~$200/mo, ~$1,200 grant) to power agent-loop development on `@flatbread/proof` and the forthcoming MCP surface.
+- **What:** Flatbread — *eat your relational markdown data and query it, too, with GraphQL* (`README.md`). A pnpm monorepo turning `.md`/YAML on disk into a typed relational graph for sites and coding agents.
+- **License:** MIT; published to npm; Node `>=20.19`; pnpm 10.33.0.
+- **Traction:** Public CI; `@flatbread/proof` DAG runner; live `examples/nextjs` + `examples/sveltekit`; PMF audit + agent-artifact thesis.
+- **Ask:** Per-maintainer **6-month Claude Max 20x** seat (~$200/mo, ~$1,200 grant) — powers maintainer IDE work *and* a continuously-running eval + preset-DAG harness on `@flatbread/proof`, not just the IDE loop.
 
 ## Eligibility checklist
 
@@ -28,47 +28,48 @@ last_updated: 2026-05-09
 | Contributor onboarding | `CONTRIBUTING.md`; pnpm workspace; documented `examples/` | `CONTRIBUTING.md`, `pnpm-workspace.yaml`, `examples/` |
 | Use-cases where Claude Max adds value | DAG runner + MCP eval harness (see below) | `packages/proof/`, this brief |
 
-> NOTE TO REVIEWER: Playbook flagged "OSI-license + no commercial gatekeeping" as UNVERIFIED — only "public repo" is explicit on the intake. We meet MIT regardless. Stars/downloads thresholds are also UNVERIFIED; submitting through the Impact track is the conservative path.
+> NOTE TO REVIEWER: OSI-license + commercial-gatekeeping and stars/dl thresholds are UNVERIFIED on intake; we meet MIT regardless and submit via Impact track.
 
 ## What we'd use Claude for
 
-**Maintainer seats — Claude Max 20x (Claude Code + Opus/Sonnet/Haiku):** 1 seat for Tony today; up to 2 if a co-maintainer lands during the grant window. Used daily for monorepo refactors, codegen on `packages/codegen`, and authoring the MCP server in `packages/flatbread`.
+**Maintainer seat — Claude Max 20x:** 1 seat for Tony today, up to 2 if a co-maintainer lands during the grant window. Daily use covers monorepo refactors, `packages/codegen`, and authoring the MCP server in `packages/flatbread`.
 
-**Claude API — `@flatbread/proof` DAG runner + agent-eval harness:**
-- `@flatbread/proof` orchestrates Cursor-SDK subagents over a typed Effort/Plan/Decision/Artifact graph. We plan to add a Claude provider alongside the existing harness so the same DAG runs against Claude Sonnet/Opus.
-- **Projected monthly token volume:** ~30–60M input + ~6–12M output tokens/month. Reasoning: ~20 DAG runs/week × ~10 nodes/run × ~30k input tokens (effort context + plan + relevant artifacts) + ~3k output tokens, plus a nightly eval sweep of ~200 fixtures × ~25k tokens. Sonnet-weighted with selective Opus on planning nodes.
-- **MCP eval harness:** scripted runs against the MCP surface to verify reference integrity (broken `Plan→Decision` links, dangling `Artifact` refs) — adds ~5–10M tokens/month.
+**Claude API — three back-half workloads on `@flatbread/proof`:**
+- **Workflow preset DAGs for complex projects.** Six parameterized presets (Phase 3 names them) + a 7th community slot — each a beachhead for a complex-project archetype, driving **use-case coverage** a single harness benchmark can't.
+- **HITL approval API around `@flatbread/proof`.** `needsApproval` on every node, Claude-Code-style plan-review gate on Decision/Plan, LangGraph-style durable pause/resume keyed to a `thread_id` Session checkpoint.
+- **Continuous-improvement evals with public dashboard.** `fixture-promote` CLI + PR-time regression-replay GH Action; failures retune per-node models, retry budgets, and HITL thresholds so the catalog self-tunes.
+- **Projected monthly token volume:** ~**80–160M input + ~16–32M output tokens/month**, ~**2–3× the prior 30–60M / 6–12M estimate** because eval and preset DAGs run continuously, not only during maintainer sessions. Arithmetic: 5 presets × ~8 runs/wk × ~12 nodes × ~25k input ≈ **52M/mo**; + ~200 fixtures × ~10k × ~30 nights ≈ **60M/mo** (regression replay); + ~5M HITL → ~115M steady state, ~160M as the catalog grows. Output ≈ 20% of input. Sonnet/Haiku-weighted, selective Opus on Decision/Plan.
 
-> NOTE TO REVIEWER: The playbook reads the offer as a *single fixed 6-month Max grant*; separate API credits are UNVERIFIED. If API credits are not in scope, the harness above runs on metered API spend and the Max seat covers maintainer-loop work only. We'd accept either shape.
+> NOTE TO REVIEWER: Separate API credits are UNVERIFIED — playbook reads offer as a 6-month Max grant only. If credits are out of scope, the workloads above run on metered spend; we'd accept either shape.
 
 ## Why Claude specifically
 
-- **MCP ecosystem participation.** Anthropic donated MCP to the Linux Foundation's Agentic AI Foundation; Flatbread's roadmap ships an **MCP surface** so coding agents (Claude Code first) can read/write the typed Effort Graph natively. We are building *for* MCP, not bolting it on.
-- **Claude Code + Skills fit.** `@flatbread/proof` is a DAG runner for harnessed coding agents — the exact shape Claude Code Skills target. The artifact shipped today (`packages/proof`) is a concrete proof-of-concept.
-- **Safety posture via typed integrity.** Our differentiator is *reference integrity for the agent-artifact layer*: typed schemas catch broken `Plan→Decision` and `Effort→Artifact` links before they cause context drift or silent regressions in long-running agent runs. This is a complement to RSP/ASL-style guardrails at the model layer.
-- **Neutral plumbing, not a wrapper.** We're an integration layer that any harness (Claude Code, Cursor, Codex) can compose against — exactly the "neutral infrastructure" stance Anthropic has rewarded in prior recipients (Apache, PSF, MCP itself).
+- **MCP ecosystem participation.** Anthropic donated MCP to the Linux Foundation; we ship an **MCP surface** so Claude Code reads/writes the typed Effort Graph natively — built *for* MCP, not bolted on.
+- **Claude Code + Skills fit.** `@flatbread/proof` is a DAG runner for harnessed coding agents — the shape Claude Code Skills target; `packages/proof` ships today.
+- **Safety posture via typed integrity.** Typed schemas catch broken `Plan→Decision` and `Effort→Artifact` links before they cause context drift in long-running agents — a complement to RSP/ASL-style guardrails at the model layer.
+- **Neutral plumbing, not a wrapper.** Any harness (Claude Code, Cursor, Codex) can compose against the Effort Graph — the "neutral infrastructure" stance Anthropic has rewarded before (Apache, PSF, MCP itself).
+- **Funder-aligned audacious bets.** Anthropic's posture on HITL (Claude Code plan mode, MCP `needsApproval`) and evals (Inspect, evals-as-research) maps directly onto Phase 4 — built *on top of* patterns Anthropic already endorses.
 
 ## Maintainer + roadmap
 
-**Maintainer:** Tony Ketcham — sole author/maintainer, merge access, npm publisher. See `CONTRIBUTING.md` and `package.json` author field.
+**Maintainer:** Tony Ketcham — sole author, merge access, npm publisher.
 
-**12-month roadmap (aligned to `flatbread-flow-pmf-audit.md` + Effort Graph MVP):**
-1. Typed `defineConfig` with full inference end-to-end.
-2. ID normalization + relation validation across collections.
-3. Watch mode parity with build mode for agent loops.
-4. **MCP server in `packages/flatbread`** exposing read/write of Effort/Plan/Decision/Session/Artifact/Run.
-5. **Effort Graph MVP** as a first-class collection set with reference-integrity checks.
-6. Generated TS adapter parallel to GraphQL (per PMF audit pivot).
-7. `@flatbread/proof` v1: Claude provider + multi-harness DAG runs.
-8. Eval harness: regression suite over fixture Effort Graphs.
-9. Docs site + Claude Code Skills examples.
-10. Case study: Flatbread-on-Flatbread (dogfood the Effort Graph for our own roadmap).
+**12-month roadmap — 4 phases, not quarters.** Front half (months 1–4) compresses foundations + Effort Graph MVP under a Codex/Claude PR train; back half (months 5–12) ships three compounding audacious bets.
+
+**Phase 1 (months 1–2) — Foundations, compressed.** Typed `defineConfig` with end-to-end inference; ID normalization across `core`, GraphQL args, generated TS; relation validation; watch-mode parity — one umbrella PR train.
+
+**Phase 2 (months 3–4) — Effort Graph MVP.** Conventions preset (Effort, Plan, Decision, Session, Artifact, Run with reference-integrity checks); schema-validated Append API; `flatbread-mcp` server exposing read + append over MCP for Claude Code, Cursor, Codex.
+
+**Phase 3 (months 5–8) — Audacious bet A: Workflow Presets.** Six shipped presets — `schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation` — each a parameterized DAG over the Effort Graph + `@flatbread/proof`. A 7th slot reserved for a community-contributed preset by month 8 to seed **community adoption**.
+
+**Phase 4 (months 9–12) — Audacious bets B + C in parallel.** **B. HITL ergonomics**: approval API with `needsApproval` on every node, Claude-Code-style plan-review gate on Decision/Plan, LangGraph-style durable pause/resume persisted as a Session. **C. Continuous-improvement evals**: `fixture-promote` CLI; PR-time regression-replay GH Action; public Inspect-View-style dashboard; eval-driven preset retuning — closing the **workflow capture** loop: every Proof DAG run is a typed Effort/Plan/Decision/Session/Artifact/Run trail the next reads.
 
 ## Public commitment
 
-- **Case studies** on running a coding-agent roadmap through `@flatbread/proof` with Claude as the model provider.
-- **MCP integration guide for Claude Code** — step-by-step on wiring the Flatbread MCP server into a Claude Code project.
-- **Eval results** — public dashboard of reference-integrity regressions caught per release, published alongside `packages/proof` runs.
+- **Case studies** on a coding-agent roadmap run through `@flatbread/proof` with Claude.
+- **MCP integration guide for Claude Code** — wiring the Flatbread MCP server into a Claude Code project.
+- **Public Inspect-View-style evals dashboard.** Reference-integrity catch rate, decision drift, cross-session recall — published continuously from the Effort Graph the evals run against, as open data for any Claude Code user.
+- **Open-source workflow preset gallery.** All six preset DAGs + the 7th community slot shipped under MIT — any Claude Code user can drop a `schema-cutover` or `release-train` into their own project directly.
 - Conference / blog talk on *git-native relational memory for coding agents*, crediting Claude for OSS.
 
 ## Form responses
@@ -76,10 +77,10 @@ last_updated: 2026-05-09
 - **Project name:** Flatbread
 - **Repo URL:** https://github.com/FlatbreadLabs/flatbread
 - **License:** MIT
-- **Primary maintainer:** Tony Ketcham (GitHub handle on file in `package.json`)
+- **Primary maintainer:** Tony Ketcham
 - **Stars / downloads:** Below 5k★/1M dl thresholds — applying via **Impact track** with `flatbread-agent-artifact-opportunity.md` as the write-up.
-- **Ask:** 6-month Claude Max 20x seat for the maintainer; API credits for the DAG runner + MCP eval harness if in scope.
-- **Timeline:** Start within 2 weeks of approval; deliverables (MCP server, Claude provider in `@flatbread/proof`, public eval dashboard) within the 6-month grant window ending **June 30, 2026** if offer aligns to that cap.
-- **Why Claude:** MCP-native roadmap, Claude Code Skills fit, typed integrity layer as a safety complement.
+- **Ask:** 6-month Claude Max 20x seat; API credits for the preset/HITL/evals workloads if in scope.
+- **Timeline:** Start within 2 weeks of approval; deliverables (MCP server, Claude provider in `@flatbread/proof`, public eval dashboard, preset gallery) within the 6-month grant window.
+- **Why Claude:** MCP-native roadmap, Claude Code Skills fit, typed integrity as safety complement, HITL/evals aligned with Anthropic's posture.
 
-> NOTE TO REVIEWER: Exact intake form fields are UNVERIFIED — playbook lists likely fields (GitHub handle, repo URL, stars/dl, recent contributions, use-cases, Impact write-up). Adjust this section to match the actual form once accessed.
+> NOTE TO REVIEWER: Exact intake form fields are UNVERIFIED.

--- a/funding-applications/openai-open-source-fund.md
+++ b/funding-applications/openai-open-source-fund.md
@@ -1,0 +1,154 @@
+---
+program: OpenAI Open Source Fund (Codex Open Source Fund)
+program_url: https://openai.com/form/codex-open-source-fund/
+applicant: Tony Ketcham
+project: Flatbread
+license: MIT
+repo_url: https://github.com/FlatbreadLabs/flatbread
+status: draft
+last_updated: 2026-05-09
+---
+
+# OpenAI Open Source Fund — Flatbread
+
+## Application form responses
+
+### First name
+
+Tony
+
+### Last name
+
+Ketcham
+
+### Email
+
+ketcham.dev@gmail.com
+
+> NOTE TO REVIEWER: confirm the email on file matches the GitHub-noreply address you want OpenAI to use for follow-up.
+
+### LinkedIn
+
+> NOTE TO REVIEWER: paste the canonical LinkedIn URL for Tony Ketcham before submitting.
+
+### GitHub
+
+https://github.com/toeknee-FlatbreadLabs
+
+> NOTE TO REVIEWER: confirm primary GitHub handle. The org is `FlatbreadLabs`; the maintainer’s personal handle should be the one with write/owner access on the org.
+
+### Which open source project are you representing?
+
+Flatbread (`@flatbread/*` on npm; `flatbread` CLI). Repo: https://github.com/FlatbreadLabs/flatbread. Monorepo of typed packages — `core`, `flatbread`, `codegen`, `config`, `source-filesystem`, `transformer-markdown`, `transformer-yaml`, `resolver-svimg`, `utils`, and `proof` — published under MIT.
+
+### Brief description of the project
+
+Flatbread is a Git-native relational content layer for TypeScript apps. The repo elevator line, verbatim: *"Eat your relational markdown data and query it, too, with GraphQL inside damn near any framework."* You point Flatbread at folders of `.md` / `.yaml` files, declare collections and refs, and get a typed object graph queryable through GraphQL today and through generated TypeScript and an MCP server next.
+
+The project is mid-pivot, documented in `flatbread-flow-pmf-audit.md` and `flatbread-agent-artifact-opportunity.md`: from "GraphQL over markdown" to **the relational layer for agent efforts in git**. We are extending the same primitives — collections, refs, filters, codegen — into an **Effort Graph** preset (Effort → Plan → Decision → Session → Artifact → Run) so coding agents like Codex, Claude Code, and Cursor can read and append durable, typed artifacts during multi-week work, instead of losing decisions between sessions.
+
+Concrete proof we already eat our own dog food: `packages/proof` ships `@flatbread/proof`, a Cursor-SDK DAG runner that decomposes a task into subagents, executes them in topological order, and writes a live `.canvas.tsx` showing nodes move `PENDING → RUNNING → FINISHED | ERROR`. This funding application itself was scoped through a Proof DAG.
+
+### GitHub repo
+
+https://github.com/FlatbreadLabs/flatbread — public, MIT, pnpm 10.33.0 monorepo, Node ≥ 20.19, CI in `.github/workflows/pipeline.yml`, `CONTRIBUTING.md`, `examples/nextjs`, `examples/sveltekit`.
+
+### Co-maintainers and roles
+
+- **Tony Ketcham** — creator, primary maintainer, package owner on npm, ships the bulk of releases; author field in `package.json`.
+- Community contributors via GitHub issues / PRs and the public Slack workspace linked from the README.
+
+> NOTE TO REVIEWER: list any additional co-maintainers with write access here before submitting; if Tony is currently sole-write, say so plainly — funders read padded lists as a negative signal.
+
+### How would you use API credits for your project?
+
+Credits go straight into Codex-driven maintainer automation and the Effort Graph proof loop — not into open-ended R&D. Itemised below; full budget table in **Funding ask**.
+
+1. **Codex-as-PR-reviewer on `FlatbreadLabs/flatbread`.** Wire Codex CLI into `pipeline.yml` so every PR gets: typed-config diff review, schema-impact summary, and an Effort/Plan link suggestion. Replaces ~6 hours/week of solo triage.
+2. **Codex-as-release-engineer.** Automate changelog generation, version bumping (`scripts/bumpVersions.ts`), and pre-publish verification (`pnpm verify`) so package releases stop being a context-switch tax.
+3. **Effort Graph evals harness.** Run Codex against synthetic Effort/Plan/Decision graphs to measure: reference-integrity catch rate, ID-normalization regressions, and watch-mode latency. Credits fund the eval calls and the regression replays.
+4. **`@flatbread/proof` self-hosted DAGs for roadmap delivery.** Each near-term PMF item (typed config, ID normalization, relation validation, watch mode) is shipped as a Proof DAG of Codex subagents under maintainer review. Credits fund the subagent calls.
+5. **Docs + cookbook generation.** Codex turns the existing PMF audit and Agent Artifact Opportunity doc into a navigable docs site with worked examples (`posts → authors → tags`, Effort Graph quickstart, MCP tool reference).
+
+### Anything else you'd like us to know?
+
+Three things.
+
+**One — we are betting on Codex specifically, not "AI in general."** The Effort Graph’s value proposition is that durable typed artifacts make agent harnesses cheaper and more accurate over multi-week efforts. Codex CLI is the harness most aligned with that thesis (PR-shaped, terminal-native, rolling out into maintainer workflows). A grant here lets Flatbread be the reference relational substrate for Codex on real projects.
+
+**Two — we already shipped the dog-food.** `@flatbread/proof` is in the public repo, used internally to plan and execute work on Flatbread itself, and runs against the Cursor SDK today. It is straightforward to add a Codex adapter; that is on the funded roadmap below.
+
+**Three — the public story writes itself.** Maintainer (Tony Ketcham) shipping a typed git-native memory layer that Codex uses to review its own PRs is the "teams using Codex to power GitHub PR workflows" archetype OpenAI has already amplified. Public progress channels are listed in **How we'll publicly share progress**.
+
+> NOTE TO REVIEWER: the live form may include an OpenAI Org ID field; if so, paste it here. The playbook flagged this as UNVERIFIED.
+
+---
+
+## Funding ask
+
+The published award is **up to $25,000 in OpenAI API credits**, plus 6 months of ChatGPT Pro with Codex and conditional Codex Security access. We are requesting the full **$25,000 in API credits** plus the bundled ChatGPT Pro / Codex Security seats for the maintainer.
+
+> NOTE TO REVIEWER: the playbook found no separate cash component for this fund. If a cash line is offered on the live form, request an additional **$15,000 USD** for maintainer time on the Effort Graph MVP and cite the budget table below. Otherwise leave cash at $0 and absorb maintainer time as in-kind.
+
+### Budget table (12 months)
+
+| Line item                                  | Allocation                  | Rationale                                                                                |
+| ------------------------------------------ | --------------------------- | ---------------------------------------------------------------------------------------- |
+| Maintainer time (Tony Ketcham)             | $0 cash / in-kind           | Absorbed unless a cash line is offered; tracked as Effort records in the graph.          |
+| MCP server build-out (`flatbread-mcp`)     | ~$6,000 in credits          | Codex-driven scaffolding, tool-schema generation, evals against Effort Graph fixtures.   |
+| Evals harness (relation integrity, IDs)    | ~$5,000 in credits          | Synthetic graphs + regression replays; Codex grades diffs against typed schemas.         |
+| Codex PR-review + release automation       | ~$5,000 in credits          | Per-PR review calls, weekly release runs, triage summarization on issue backlog.         |
+| Docs site + cookbook generation            | ~$4,000 in credits          | Codex generates worked examples, API references, migration notes from existing docs.    |
+| Contributor sponsorship (paid via OSS Pay) | ~$5,000 in credits + ChatGPT Pro seats for top 2 outside contributors | Lowers the bus-factor concern and rewards real PR landings. |
+| **Total**                                  | **~$25,000 in API credits** |                                                                                          |
+
+> NOTE TO REVIEWER: confirm whether the fund permits redistributing ChatGPT Pro / Codex seats to non-maintainer contributors before promising sponsorship seats publicly.
+
+---
+
+## 12-month milestone roadmap
+
+Aligned with the PMF audit near-term list and the Effort Graph MVP from `flatbread-agent-artifact-opportunity.md` (Posture C — recommended).
+
+**Q1 (months 1–3) — Foundations the agent layer needs anyway.**
+
+- Typed config: kill loose `any` surfaces in `packages/config`; generate config types from a single source.
+- ID normalization: stable, comparable IDs across `core`, GraphQL args, and generated TS.
+- First Codex-as-PR-reviewer integration landed in `pipeline.yml`.
+
+**Q2 (months 4–6) — Integrity and dev loop.**
+
+- Relation validation with diagnostics: missing targets, duplicate IDs, cardinality violations fail at load.
+- Unified watch mode: edit `.md`/`.yaml`, schema rebuilds, types regenerate, examples hot-update.
+- `@flatbread/proof` Codex adapter alongside the Cursor SDK runner.
+
+**Q3 (months 7–9) — Effort Graph MVP.**
+
+- Conventions preset: Effort, Plan, Decision, Session, Artifact, Run as first-class collections.
+- Append API: safe, schema-validated writes from harnesses (no CMS, no UI).
+- `flatbread-mcp` server: read + append tools exposed over MCP for Codex / Claude Code / Cursor.
+
+**Q4 (months 10–12) — Adoption and evals.**
+
+- Public eval harness comparing harness behaviour with vs without an Effort Graph (token spend, decision drift, cross-session recall).
+- Docs site live; one canonical "posts → authors → tags" quickstart and one "Effort Graph for a real PR" walkthrough.
+- v1.0 release of `flatbread` and `@flatbread/proof`.
+
+---
+
+## How we'll publicly share progress
+
+- **Monthly public update** in `FlatbreadLabs/flatbread` Discussions, cross-posted to the Slack workspace linked from the README, with concrete diffs (typed-config %, validation errors caught, watch-mode latency).
+- **Per-release notes** generated by the funded Codex release-engineer pipeline; CHANGELOG entries link back to the Effort that produced them.
+- **One write-up per quarter** on the maintainer’s blog: what Codex shipped vs what the human shipped, with a real Effort Graph from the repo as the running example. OpenAI is welcome to amplify or reuse any of it.
+- **Eval results published** in `funding-research/` and the docs site — including failure cases — so adopters can audit the integrity claims rather than trust the marketing.
+
+---
+
+## Why now / why us
+
+The agent-artifact layer in 2026 has dense conventions (`AGENTS.md`, `SKILL.md`, `.handoff/`, `.GCC/`, vault MCPs) and almost no typed relational schema across them. Search and backlinks exist; reference integrity, stable cross-tool IDs, and predicate-rich queries do not. Flatbread already models collections, refs, and Mongo-style filters over markdown/YAML in git — the exact primitives the missing layer needs (`flatbread-agent-artifact-opportunity.md`, §5).
+
+We are credible on execution, not just thesis. `@flatbread/proof` is a working Cursor-SDK DAG runner shipped in this same monorepo (`packages/proof`); it decomposes work into subagents, runs them in topological order, and writes a live canvas — Flatbread already eats its own dog food on agentic workflows. The maintainer (Tony Ketcham) authors the packages, runs the releases, and wrote both the PMF audit and the Effort Graph opportunity memo. The roadmap above is not aspiration; the near-term items are already on the public PMF audit and the proof package is already on npm.
+
+What an OpenAI Open Source Fund grant unlocks is **time compression**: Codex doing the maintainer toil (PR review, releases, eval grading, docs) so the human can ship the Effort Graph MVP and the MCP server in 12 months instead of 24. That is the bet — typed git-native memory for Codex-driven work, written by a maintainer who is already doing it in public.

--- a/funding-applications/openai-open-source-fund.md
+++ b/funding-applications/openai-open-source-fund.md
@@ -62,13 +62,15 @@ https://github.com/FlatbreadLabs/flatbread — public, MIT, pnpm 10.33.0 monorep
 
 ### How would you use API credits for your project?
 
-Credits go straight into Codex-driven maintainer automation and the Effort Graph proof loop — not into open-ended R&D. Itemised below; full budget table in **Funding ask**.
+Credits go straight into Codex-driven maintainer automation and three audacious bets stacked on top of the Effort Graph — not into open-ended R&D. Front half (~2 bullets) compresses foundations + Effort Graph MVP; back half (~5 bullets) funds workflow presets, HITL ergonomics around `@flatbread/proof` DAGs, and a continuous evals/research loop. Full budget table in **Funding ask**.
 
-1. **Codex-as-PR-reviewer on `FlatbreadLabs/flatbread`.** Wire Codex CLI into `pipeline.yml` so every PR gets: typed-config diff review, schema-impact summary, and an Effort/Plan link suggestion. Replaces ~6 hours/week of solo triage.
-2. **Codex-as-release-engineer.** Automate changelog generation, version bumping (`scripts/bumpVersions.ts`), and pre-publish verification (`pnpm verify`) so package releases stop being a context-switch tax.
-3. **Effort Graph evals harness.** Run Codex against synthetic Effort/Plan/Decision graphs to measure: reference-integrity catch rate, ID-normalization regressions, and watch-mode latency. Credits fund the eval calls and the regression replays.
-4. **`@flatbread/proof` self-hosted DAGs for roadmap delivery.** Each near-term PMF item (typed config, ID normalization, relation validation, watch mode) is shipped as a Proof DAG of Codex subagents under maintainer review. Credits fund the subagent calls.
-5. **Docs + cookbook generation.** Codex turns the existing PMF audit and Agent Artifact Opportunity doc into a navigable docs site with worked examples (`posts → authors → tags`, Effort Graph quickstart, MCP tool reference).
+1. **Codex-driven foundation toil + Effort Graph MVP (Phase 1 + 2).** One umbrella PR train covers typed `defineConfig`, ID normalization, relation validation, and watch-mode parity, then ships the Conventions preset, Append API, and `flatbread-mcp` server. Codex-as-PR-reviewer wired into `pipeline.yml` (typed-config diff review, schema-impact summary, Effort/Plan link suggestion) and Codex-as-release-engineer (changelog, `scripts/bumpVersions.ts`, `pnpm verify`) absorb the per-PR and per-release calls. ~2 months of dense, bounded credit spend; everything downstream depends on it landing on time.
+2. **`@flatbread/proof` self-hosted DAGs as the roadmap delivery vehicle.** Every Phase 3/4 deliverable ships as a Proof DAG of Codex subagents under maintainer review, writing back into Effort/Plan/Decision/Session/Artifact/Run. Credits fund subagent calls and golden-trace generation; the same DAG runs become Phase-4 eval fixtures, so the spend compounds.
+3. **Workflow preset catalog for complex projects (Phase 3 — largest single line).** Six named, parameterized DAGs over the Effort Graph: `schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation`. Sized at ~10 build-out runs × ~12 nodes × ~25k input tokens per preset; Decision/Plan default to GPT-5-class, Artifact/Session default to Codex-mini. Drives **use-case coverage**; a seventh slot is held for a community-contributed preset by month 8.
+4. **HITL ergonomics around `@flatbread/proof` DAGs (Phase 4 / bet B).** Approval API with first-class `needsApproval` boundaries, Claude-Code-style plan-review gate against the live Effort Graph, and LangGraph-style durable pause/resume keyed to a `thread_id` Session checkpoint. Credits fund per-node approval evals and the resume-correctness fixture suite that proves a paused DAG resumes days later without re-firing tool calls.
+5. **Continuous-improvement evals + research loop — fixture growth (Phase 4 / bet C, part 1).** `fixture-promote` CLI turns any failing Proof trace into a versioned eval fixture; nightly sweeps replay the catalog against the Effort Graph it was authored from. Sized at ~200 promoted fixtures × ~30 nights × ~10k input tokens — the line item that makes the catalog self-improving rather than static.
+6. **PR-time regression replay + public Inspect-View dashboard (bet C, part 2).** GitHub Action replays the eval catalog on every PR — failures block merge or open a Decision for HITL override. A public dashboard publishes reference-integrity catch rate, decision drift, and cross-session recall per release; eval-driven preset retuning feeds failure mining back into per-node model selection, retry budgets, and HITL thresholds.
+7. **Docs / cookbook / contributor sponsorship.** One worked example per preset, an MCP cookbook against `flatbread-mcp`, and credit-share for the first two outside contributors landing a preset or a fixture pack. Modest line, real **community adoption** lever — the catalog is only credible once non-maintainers ship into it.
 
 ### Anything else you'd like us to know?
 
@@ -76,9 +78,9 @@ Three things.
 
 **One — we are betting on Codex specifically, not "AI in general."** The Effort Graph’s value proposition is that durable typed artifacts make agent harnesses cheaper and more accurate over multi-week efforts. Codex CLI is the harness most aligned with that thesis (PR-shaped, terminal-native, rolling out into maintainer workflows). A grant here lets Flatbread be the reference relational substrate for Codex on real projects.
 
-**Two — we already shipped the dog-food.** `@flatbread/proof` is in the public repo, used internally to plan and execute work on Flatbread itself, and runs against the Cursor SDK today. It is straightforward to add a Codex adapter; that is on the funded roadmap below.
+**Two — the grant unlocks three audacious bets stacked on top of the dog-food.** `@flatbread/proof` is already in the public repo, used internally to plan and execute work on Flatbread itself, and runs against the Cursor SDK today; the Codex adapter is on the funded roadmap. After the foundation toil and Effort Graph MVP land in Phases 1–2, the credits then fund (a) **workflow presets for complex projects** — six parameterized DAGs (`schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation`) over `@flatbread/proof` and the Effort Graph; (b) **HITL ergonomics** around those DAGs (approval API, Claude-Code-style plan-review gate, LangGraph-style durable pause/resume keyed to `thread_id` Session checkpoints); and (c) a **continuous evals + research loop** (`fixture-promote` CLI, PR-time regression-replay GitHub Action, public Inspect-View dashboard, eval-driven preset retuning). These are the bets the credits buy that maintainer-toil-only would not.
 
-**Three — the public story writes itself.** Maintainer (Tony Ketcham) shipping a typed git-native memory layer that Codex uses to review its own PRs is the "teams using Codex to power GitHub PR workflows" archetype OpenAI has already amplified. Public progress channels are listed in **How we'll publicly share progress**.
+**Three — the public story writes itself: use-case coverage, community adoption, workflow capture.** Each of the six shipped presets is a beachhead for a real complex-project archetype (**use-case coverage**). A seventh community-contributed preset slot, the MCP cookbook, and credit-share for the first two outside contributors landing a preset or fixture pack seed **community adoption**. And every Proof DAG run produces a typed Effort/Plan/Decision/Session/Artifact/Run trail the next run reads — **workflow capture** as a first-class artifact rather than a side-effect. Maintainer (Tony Ketcham) shipping a typed git-native memory layer that Codex uses to review its own PRs is the "teams using Codex to power GitHub PR workflows" archetype OpenAI has already amplified. Public progress channels are listed in **How we'll publicly share progress**.
 
 > NOTE TO REVIEWER: the live form may include an OpenAI Org ID field; if so, paste it here. The playbook flagged this as UNVERIFIED.
 
@@ -88,19 +90,19 @@ Three things.
 
 The published award is **up to $25,000 in OpenAI API credits**, plus 6 months of ChatGPT Pro with Codex and conditional Codex Security access. We are requesting the full **$25,000 in API credits** plus the bundled ChatGPT Pro / Codex Security seats for the maintainer.
 
-> NOTE TO REVIEWER: the playbook found no separate cash component for this fund. If a cash line is offered on the live form, request an additional **$15,000 USD** for maintainer time on the Effort Graph MVP and cite the budget table below. Otherwise leave cash at $0 and absorb maintainer time as in-kind.
+> NOTE TO REVIEWER: the playbook found no separate cash component for this fund. If a cash line is offered on the live form, request an additional **$15,000 USD** for maintainer time on the workflow presets catalog and HITL ergonomics surfaces (Phase 3 + 4 — the audacious bets the credits alone can't fully cover) and cite the budget table below. Otherwise leave cash at $0 and absorb maintainer time as in-kind.
 
 ### Budget table (12 months)
 
-| Line item                                  | Allocation                  | Rationale                                                                                |
-| ------------------------------------------ | --------------------------- | ---------------------------------------------------------------------------------------- |
-| Maintainer time (Tony Ketcham)             | $0 cash / in-kind           | Absorbed unless a cash line is offered; tracked as Effort records in the graph.          |
-| MCP server build-out (`flatbread-mcp`)     | ~$6,000 in credits          | Codex-driven scaffolding, tool-schema generation, evals against Effort Graph fixtures.   |
-| Evals harness (relation integrity, IDs)    | ~$5,000 in credits          | Synthetic graphs + regression replays; Codex grades diffs against typed schemas.         |
-| Codex PR-review + release automation       | ~$5,000 in credits          | Per-PR review calls, weekly release runs, triage summarization on issue backlog.         |
-| Docs site + cookbook generation            | ~$4,000 in credits          | Codex generates worked examples, API references, migration notes from existing docs.    |
-| Contributor sponsorship (paid via OSS Pay) | ~$5,000 in credits + ChatGPT Pro seats for top 2 outside contributors | Lowers the bus-factor concern and rewards real PR landings. |
-| **Total**                                  | **~$25,000 in API credits** |                                                                                          |
+| Line item                                          | Allocation                  | Rationale                                                                                                              |
+| -------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Foundation Codex toil (compressed)                 | $2,500 in credits           | Typed config, ID normalization, relation validation, watch mode — 2 months of dense PR review/codegen.                  |
+| Effort Graph + `flatbread-mcp` server              | $3,000 in credits           | Conventions preset, append API, MCP tool scaffolding, fixture-backed integration tests.                                |
+| Workflow preset DAGs (Phase 3 — largest line)      | $8,000 in credits           | Six presets × ~10 build-out DAG runs + golden-trace generation. The bet that drives use-case coverage.                  |
+| HITL ergonomics surfaces                           | $3,500 in credits           | Approval API, plan-review gate, durable pause/resume; UI scaffolding + resume-correctness fixtures.                    |
+| Evals + continuous-improvement loop                | $5,000 in credits           | Nightly sweeps, fixture-promotion CLI, PR-time regression replay, public dashboard, eval-driven preset retuning.       |
+| Docs / cookbook / contributor sponsorship          | $3,000 in credits + ChatGPT Pro seats for top 2 outside contributors | Worked examples per preset, MCP cookbook, credit-share for the first two outside contributors landing a preset or fixture pack. |
+| **Total**                                          | **$25,000 in API credits**  |                                                                                                                        |
 
 > NOTE TO REVIEWER: confirm whether the fund permits redistributing ChatGPT Pro / Codex seats to non-maintainer contributors before promising sponsorship seats publicly.
 
@@ -108,31 +110,54 @@ The published award is **up to $25,000 in OpenAI API credits**, plus 6 months of
 
 ## 12-month milestone roadmap
 
-Aligned with the PMF audit near-term list and the Effort Graph MVP from `flatbread-agent-artifact-opportunity.md` (Posture C — recommended).
+Four phases, not quarters. Front half (months 1–4) compresses foundations + Effort Graph MVP; back half (months 5–12) ships three compounding bets: **workflow presets → HITL ergonomics → continuous-improvement evals loop**.
 
-**Q1 (months 1–3) — Foundations the agent layer needs anyway.**
+### Phase 1 (months 1–2) — Foundations, compressed
 
-- Typed config: kill loose `any` surfaces in `packages/config`; generate config types from a single source.
-- ID normalization: stable, comparable IDs across `core`, GraphQL args, and generated TS.
-- First Codex-as-PR-reviewer integration landed in `pipeline.yml`.
+Front-loaded onto Codex/Claude toil; human review only. Four items ship under one umbrella PR train.
 
-**Q2 (months 4–6) — Integrity and dev loop.**
+- **Typed `defineConfig` with end-to-end inference.** Codex-as-PR-reviewer drafts type-erasure removals in `packages/config`; maintainer reviews/merges.
+- **ID normalization across `core`, GraphQL args, generated TS.** Claude Code Skill scaffolds, Codex shards per-collection PRs, maintainer adjudicates edges.
+- **Relation validation with diagnostics.** Stub failing-fixture promotion (Phase 4) so future broken refs land as cases; Codex drafts diagnostic copy.
+- **Watch-mode parity with build mode.** `@flatbread/proof` reuses watch events; Codex drafts the watcher refactor, maintainer reviews concurrency.
 
-- Relation validation with diagnostics: missing targets, duplicate IDs, cardinality violations fail at load.
-- Unified watch mode: edit `.md`/`.yaml`, schema rebuilds, types regenerate, examples hot-update.
-- `@flatbread/proof` Codex adapter alongside the Cursor SDK runner.
+### Phase 2 (months 3–4) — Effort Graph MVP, compressed
 
-**Q3 (months 7–9) — Effort Graph MVP.**
+Three deliverables, one quickstart ("Effort Graph for a real PR").
 
-- Conventions preset: Effort, Plan, Decision, Session, Artifact, Run as first-class collections.
-- Append API: safe, schema-validated writes from harnesses (no CMS, no UI).
-- `flatbread-mcp` server: read + append tools exposed over MCP for Codex / Claude Code / Cursor.
+- **Conventions preset.** Effort, Plan, Decision, Session, Artifact, Run as first-class collections with reference-integrity checks; codegen produces the typed read API.
+- **Append API.** Schema-validated writes from harnesses, no CMS, no UI. The same validators that catch broken refs at load now reject malformed appends.
+- **`flatbread-mcp` server.** Read + append tools exposed over MCP for Codex, Claude Code, and Cursor against the same Effort Graph schema.
 
-**Q4 (months 10–12) — Adoption and evals.**
+### Phase 3 (months 5–8) — Audacious bet A: Workflow Presets for Complex Projects
 
-- Public eval harness comparing harness behaviour with vs without an Effort Graph (token spend, decision drift, cross-session recall).
-- Docs site live; one canonical "posts → authors → tags" quickstart and one "Effort Graph for a real PR" walkthrough.
-- v1.0 release of `flatbread` and `@flatbread/proof`.
+Six shipped presets, each a parameterized DAG composed with the Effort Graph and run through `@flatbread/proof`. Decision/Plan default to Opus / GPT-5-class; Artifact/Session default to Sonnet/Haiku/Codex-mini; all write back into Effort/Plan/Decision/Session/Artifact/Run.
+
+- **`schema-cutover`** — old + new schema, codegen target. Decision → Plan → codegen + shard Artifacts → test Runs → HITL pre-merge.
+- **`release-train`** — package graph + semver. Decision → changelog Plan → per-package Artifact → canary Sessions → HITL pre-publish.
+- **`research-compendium`** — topic + sources. Outline Decision → section Plans → draft Sessions → cite-check Run → HITL.
+- **`docs-site-refactor`** — IA tree + redirect map. Decision → page-level Plan → MDX Artifacts → broken-link Run → HITL.
+- **`api-version-cutover`** — facade + traffic-shift schedule. Decision → migration Plan → adapter Artifacts → contract-test Run → HITL canary.
+- **`design-system-token-rotation`** — token map + visual-regression budget. Decision → token Plan → component codemod Artifacts → snapshot Run → HITL.
+
+A seventh slot is reserved for a community-contributed preset by month 8 to seed the contributor pipeline.
+
+### Phase 4 (months 9–12) — Audacious bets B + C in parallel
+
+Run B and C overlapping: each preset run produces both an HITL surface and an eval fixture, so they ship cheapest together.
+
+**B. HITL ergonomics around `@flatbread/proof` + the Effort Graph**
+
+- **Approval API.** First-class `needsApproval` boundary on every DAG node, surfaced through the MCP server and a thin web review pane.
+- **Plan-review gate.** Mirrors Claude Code plan mode: Decision/Plan nodes pause, surface a diff-able markdown plan against the live Effort Graph, proceed only once a human signs the Decision.
+- **Durable pause/resume.** LangGraph-style `interrupt()` keyed to a `thread_id` checkpoint, persisted as a Session record so a paused DAG resumes days later without re-firing tool calls.
+
+**C. Continuous-improvement evals + research loop**
+
+- **`fixture-promote` CLI.** Promotes any failing Proof DAG trace into a versioned eval fixture.
+- **PR-time regression-replay GitHub Action.** Replays the catalog against the PR; failures block merge or open a Decision for HITL override.
+- **Public eval dashboard.** Inspect-View-style; reference-integrity catch rate, decision drift, cross-session recall — published from the Effort Graph the evals run against.
+- **Eval-driven preset tuning.** Failure mining feeds back into preset DAG defaults (per-node model selection, retry budgets, HITL thresholds) — the catalog becomes self-improving.
 
 ---
 
@@ -142,13 +167,12 @@ Aligned with the PMF audit near-term list and the Effort Graph MVP from `flatbre
 - **Per-release notes** generated by the funded Codex release-engineer pipeline; CHANGELOG entries link back to the Effort that produced them.
 - **One write-up per quarter** on the maintainer’s blog: what Codex shipped vs what the human shipped, with a real Effort Graph from the repo as the running example. OpenAI is welcome to amplify or reuse any of it.
 - **Eval results published** in `funding-research/` and the docs site — including failure cases — so adopters can audit the integrity claims rather than trust the marketing.
+- **Public evals dashboard, refreshed quarterly** — Inspect-View-style regression results across the growing catalog of product-case fixtures (`schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation`, plus community-contributed presets), so the catalog's failure-and-recovery curve is visible to adopters and amplifiers in one place.
 
 ---
 
 ## Why now / why us
 
-The agent-artifact layer in 2026 has dense conventions (`AGENTS.md`, `SKILL.md`, `.handoff/`, `.GCC/`, vault MCPs) and almost no typed relational schema across them. Search and backlinks exist; reference integrity, stable cross-tool IDs, and predicate-rich queries do not. Flatbread already models collections, refs, and Mongo-style filters over markdown/YAML in git — the exact primitives the missing layer needs (`flatbread-agent-artifact-opportunity.md`, §5).
+The agent-artifact layer in 2026 has dense conventions (`AGENTS.md`, `SKILL.md`, `.handoff/`, `.GCC/`, vault MCPs) and almost no typed relational schema across them. Flatbread already models collections, refs, and Mongo-style filters over markdown/YAML in git, and `@flatbread/proof` already runs DAGs of subagents against that graph — shipped in this same monorepo (`packages/proof`), used internally to plan and execute work on Flatbread itself. The missing unlock is not another harness or memory format — it is **workflow capture**: durable, parameterized presets for the specific shapes of complex work (schema cutovers, release trains, docs refactors, API cutovers, token rotations, research compendiums) that a coding agent picks up, hydrates from an Effort Graph, and resumes across sessions. The framing is the public Effort Graph opportunity memo (`flatbread-agent-artifact-opportunity.md`, §5, Posture C), built on the PMF-audit pivot.
 
-We are credible on execution, not just thesis. `@flatbread/proof` is a working Cursor-SDK DAG runner shipped in this same monorepo (`packages/proof`); it decomposes work into subagents, runs them in topological order, and writes a live canvas — Flatbread already eats its own dog food on agentic workflows. The maintainer (Tony Ketcham) authors the packages, runs the releases, and wrote both the PMF audit and the Effort Graph opportunity memo. The roadmap above is not aspiration; the near-term items are already on the public PMF audit and the proof package is already on npm.
-
-What an OpenAI Open Source Fund grant unlocks is **time compression**: Codex doing the maintainer toil (PR review, releases, eval grading, docs) so the human can ship the Effort Graph MVP and the MCP server in 12 months instead of 24. That is the bet — typed git-native memory for Codex-driven work, written by a maintainer who is already doing it in public.
+Six named presets with HITL gates and a self-improving eval loop drive the three things this project most needs: **use-case coverage** (each preset is a beachhead for a real complex-project archetype), **community adoption** (contributors land their own presets and fixtures once the catalog is open), and **workflow capture** itself (every Proof DAG run is a typed Effort/Plan/Decision/Session/Artifact/Run trail the next run reads). A solo MIT maintainer — Tony Ketcham, who authors the packages, runs the releases, and wrote both the PMF audit and the opportunity memo — can ship this in twelve months only because Codex does the foundation toil up front and the eval loop tunes presets after. Funded agent toil turns a 24-month roadmap into a 12-month one; that is the bet, written by a maintainer who is already doing it in public.

--- a/funding-research/funding-program-landscape.md
+++ b/funding-research/funding-program-landscape.md
@@ -1,0 +1,208 @@
+---
+title: Flatbread Funding Program Landscape
+project: Flatbread
+prepared_for: maintainer review
+last_updated: 2026-05-09
+status: draft
+---
+
+## TL;DR — top 5 to pursue
+
+| Rank | Program | Category | Award type | Effort | Win prob. | Why-it-fits |
+|------|---------|----------|------------|--------|-----------|-------------|
+| 1 | Anthropic Claude for OSS | AI-lab | Credits (Claude Max 20x, 6 mo) | LOW | HIGH | Direct-fit ecosystem track for an AI-agent tooling repo; deadline Jun 30 2026, 10k cap. *In flight.* |
+| 2 | OpenAI Codex OSS Fund | AI-lab | Credits (≤$25k API + 6 mo Codex/ChatGPT Pro) | LOW | HIGH | OSS-direct, rolling, $1M pool; agentic dev-tooling is squarely in scope. *In flight.* |
+| 3 | Vercel OSS Program | Infra/credits | Credits ($3.6k/12 mo + Starter Pack) | LOW | HIGH | Maintainer-track grant for public OSS repos; minimal paperwork, MIT/TS friendly. |
+| 4 | Sovereign Tech Fund | Foundation | Cash (€50k+) | HIGH | MED | "Open digital base technology — libs, package mgrs, dev tooling" is Flatbread's exact lane; OSI license satisfied (MIT). |
+| 5 | Sentry OSS Grant + FOSS Fund | Foundation | Cash ($10k/3-mo grant + thanks.dev/OSC payouts) | LOW | MED | Dev-tools focus; grant rolls quarterly and stacks with Sentry's $750k+/yr FOSS Fund pipeline. |
+
+Honorable mentions: NLnet NGI0 Commons (great band, EU angle needed), Open Source Collective (fiscal-host gateway, unlocks several rows above).
+
+## Full landscape
+
+### AI-lab + AI-platform programs
+
+- **OpenAI Codex OSS Fund** — https://openai.com/form/codex-open-source-fund. Ask: ≤$25k API credits + 6 mo Codex/ChatGPT Pro; $1M pool, rolling. Eligibility: public OSS repo with active maintainership. Verdict: HIGH. Action: **Apply** (in flight).
+- **Anthropic Claude for OSS** — https://claude.com/open-source-max. Ask: 6 mo Claude Max 20x. Eligibility: 5k★ / 1M npm-mo OR ecosystem-track narrative; deadline Jun 30 2026, capped at 10k recipients. Verdict: HIGH. Action: **Apply** (in flight) via ecosystem track.
+- **Anthropic Economic Futures** — https://anthropic.com/economic-futures. Ask: $10–50k cash + $5k Claude credits. Eligibility: economist/PhD AI-impact research. Verdict: LOW. Action: **Skip** — research grant, not a tools grant.
+- **Google for Startups Cloud AI** — https://cloud.google.com/startup/ai. Ask: ≤$350k GCP + Gemini. Eligibility: AI-first startup, VC seed–A. Verdict: MED. Action: **Skip for now** — VC-gated; revisit if Flatbread incorporates and raises.
+- **Google OSPO / Google.org** — https://opensource.googleblog.com. Ask: GSoC stipends $1.5–6k; AI-for-Sci/Gov ($30M, nonprofits). Verdict: MED. Action: **Apply if blocked status changes** — needs mentor org or 501(c)(3); GSoC is the realistic surface once Flatbread can host a project idea.
+- **Microsoft for Startups Azure** — https://foundershub.startups.microsoft.com. Ask: $5k self / ≤$150k investor-track. Verdict: MED. Action: **Skip** unless Flatbread builds Azure-hosted demos.
+- **AWS Activate** — https://aws.amazon.com/startups/credits. Ask: $1k–$100k Bedrock-eligible. Verdict: MED. Action: **Skip** unless Flatbread relies on AWS.
+- **Cloudflare Workers Launchpad** — https://cloudflare.com/startups/workers-launchpad. Ask: $2B VC pool + Startup Enterprise. Verdict: LOW. Action: **Skip** — VC-stage, on-Workers requirement.
+- **Vercel OSS Program** — https://vercel.com/open-source-program. Ask: $3.6k/12 mo + Starter Pack. Verdict: HIGH. Action: **Apply**.
+- **Hugging Face GPU Grants** — https://huggingface.co/docs/hub/spaces-gpus. Ask: free ZeroGPU/T4 for Spaces; cash UNVERIFIED. Verdict: MED. Action: **Apply if blocked status changes** — only if Flatbread ships an HF Space demo.
+- **Cohere Labs Catalyst** — https://cohere.ai/research/grants. Ask: rolling API credits, academic/civic. Verdict: LOW. Action: **Skip** — academic skew.
+- **Together AI Research Credits** — https://together.ai. Verdict: LOW. Action: **Skip** — invite-only.
+- **Mistral Mistralship + Hackathon** — https://mistral.ai. Ask: ≤$30k credits; hackathon Feb 28–Mar 1 2026, $200k prizes. Verdict: MED. Action: **Apply if blocked status changes** — fits if a Mistral-on-Flatbread demo exists.
+- **Replicate Startup Credits** — https://replicate.com. Ask: $1k–$10k inference, 6 mo. Verdict: MED. Action: **Skip** unless inference-bound.
+- **Cursor Startup Program** — https://cursor.com. Ask: $500–$5k Pro by stage; OSS track UNVERIFIED. Verdict: LOW. Action: **Apply if blocked status changes** — confirm OSS track exists.
+
+### Foundation + public-interest grants
+
+- **Sovereign Tech Fund** — https://sovereign.tech. Ask: €50k+, rolling, ~10-week review, OSI license required. Eligibility: open digital base tech, infra/dev-tooling lens. Verdict: HIGH. Action: **Apply** — needs a polished maintenance plan + budget.
+- **NLnet NGI0 Commons** — https://nlnet.nl/commonsfund. Ask: €5–50k scalable, bi-monthly cycles; next deadline Jun 1 2026. Eligibility: EU-priority, non-EU OK with explicit EU upside. Verdict: HIGH. Action: **Apply** — must articulate EU angle (maintainer geography UNVERIFIED).
+- **NLnet NGI0 Core** — https://nlnet.nl/core. Same band/cadence; infra-architecture lens. Verdict: MED. Action: **Apply if blocked status changes** — once Flatbread is positioned as an internet-architecture component.
+- **Open Source Collective** — https://oscollective.org. Ask: fiscal host, 10% fee; 501(c)(6) (non-tax-deductible). Verdict: HIGH (gateway). Action: **Apply** — unblocks Sentry/thanks.dev and most foundation flows.
+- **Sentry OSS Grant + FOSS Fund** — https://blog.sentry.io. Ask: $10k/3-mo grant + $750k+/yr distributed via thanks.dev / OSC / GitHub Sponsors. Verdict: HIGH. Action: **Apply**.
+- **LF LFX Mentorship** — https://lfx.linuxfoundation.org. Ask: $3–6k stipends, 3 cycles/yr. Verdict: MED. Action: **Apply if blocked status changes** — pays contributors, requires LF umbrella.
+- **OpenJS Incubation** — https://openjsf.org (new-projects@lists.openjsf.org). Ask: no direct $; legitimacy + sponsor gateway. Verdict: MED. Action: **Apply if blocked status changes** — viable once Flatbread has a stable governance model.
+- **thanks.dev** — https://thanks.dev. Ask: algorithmic dep-tree payouts (Sentry, Canonical, Codecov sponsors); ~$10–$150/proj/mo. Verdict: MED. Action: **Apply** — passive income once Flatbread is in dependency graphs.
+- **NGI Sargasso** — https://ngisargasso.eu. Verdict: LOW (closed Nov 2024). Action: **Skip**.
+- **OTF Internet Freedom Fund** — https://opentech.fund. Verdict: LOW. Action: **Skip** — anti-censorship scope only.
+- **Mozilla MOSS** — https://mozilla.org/moss. Verdict: LOW (hiatus since 2020). Action: **Skip**.
+- **Mozilla Builders / Tech Fund / Democracy×AI** — https://builders.mozilla.org, https://mozillafoundation.org. Verdict: LOW. Action: **Skip** — Local-AI / democracy themes.
+- **ISOC Beyond the Net** — https://isocfoundation.org. Verdict: LOW. Action: **Skip** — chapters only.
+- **Apache Incubator** — https://incubator.apache.org. Verdict: LOW. Action: **Skip** — no $, requires 3+ sponsoring orgs and Apache 2.0.
+- **CHAOSS** — https://chaoss.community. Verdict: LOW. Action: **Skip** — no grants.
+- **CNCF Sandbox** — https://cncf.io. Verdict: LOW today. Action: **Apply if blocked status changes** — viable once Flatbread's relations layer ships and a cloud-native angle is credible; IP transfer required.
+- **GitHub Accelerator** — https://accelerator.github.com. Verdict: LOW (last cohort 2024; no 2026 round announced). Action: **Skip** until/unless reopened.
+
+### Infra + credits programs
+
+- **Vercel for Startups** — https://vercel.com/startups. Ask: VC/accelerator-partner credits. Action: **Apply if blocked status changes** — partner proof needed.
+- **Netlify Open Source** — https://opensource-form.netlify.com (policy: https://www.netlify.com/legal/open-source-policy). Ask: credits + OSS badge. Action: **Apply** — useful for docs hosting.
+- **Cloudflare Workers** — https://developers.cloudflare.com/workers/platform/pricing. Ask: free tier (KV + Queues free). Action: **Apply** — edge build/preview.
+- **Fly.io OSS** — https://fly.io/docs/about/open-source/. Ask: ad-hoc credits. Action: **Apply if blocked status changes** — speculative; ask only with concrete need.
+- **Railway OSS** — https://railway.com/partners. Ask: template-kickback revenue. Action: **Apply** — list a Flatbread starter template.
+- **Render** — https://render.com/docs/free. Ask: hobby/idle caps. Action: **Apply** — demo hosting.
+- **Supabase** — https://supabase.com/pricing. Ask: free DB / auth / storage / functions tier. Action: **Apply** — backend for example apps.
+- **npm** — https://www.npmjs.com. Ask: free public packages. Action: **Apply** — already the registry.
+- **GitHub Packages** — https://docs.github.com/en/billing/managing-billing-for-github-packages. Ask: $0 public artifacts. Action: **Apply** — secondary artifact channel.
+- **Algolia DocSearch** — https://docsearch.algolia.com. Ask: hosted search for OSS docs. Action: **Apply** — once docs site is live.
+- **Sentry OSS** — https://sentry.io/for/open-source. Ask: sponsored Sentry plan. Action: **Apply**.
+- **Honeycomb for Builders** — https://www.honeycomb.io/honeycomb-for-builders. Ask: free Pro (apply). Action: **Apply if blocked status changes** — useful once tracing is in scope.
+- **Datadog OSS** — https://www.datadoghq.com/partner/open-source. Ask: sponsored OSS APM. Action: **Apply if blocked status changes** — only if Flatbread hosts a service tier.
+- **PostHog** — https://posthog.com/pricing (startups: https://posthog.com/startups). Ask: free Cloud + startup credits. Action: **Apply** — analytics for the docs site.
+- **Notion Nonprofits** — https://www.notion.com/pages/nonprofits. Ask: 50% off Plus via TechSoup. Action: **Apply if blocked status changes** — needs 501(c)(3).
+- **Linear Startups** — https://linear.app/startups (pricing: https://linear.app/pricing). Ask: paid promotional credits. Action: **Skip** unless team grows past free caps.
+- **Open Collective** — https://opencollective.com. Ask: fiscal-host platform for recurring contributions. Action: **Apply** — host under OSC.
+- **GitHub Sponsors** — https://github.com/sponsors. Ask: patron rail. Action: **Apply** — set up immediately.
+- **Polar.sh** — https://polar.sh. Ask: subs + per-issue funding. Action: **Apply** — monetize roadmap items.
+- **thanks.dev** — https://thanks.dev. Ask: corporate dep-tree payouts. Action: **Apply** — B2B passive rail.
+- **Tidelift** — https://tidelift.com. Ask: enterprise subscriptions for maintained OSS. Verdict: MED. Action: **Apply if blocked status changes** — needs enterprise downstream usage.
+
+### Academic + governmental research funding
+
+- **NSF SBIR/STTR Phase I** — https://seedfund.nsf.gov. Eligibility: US for-profit small business; STTR requires nonprofit research partner. Verdict: LOW for an individual maintainer. Action: **Skip** until Flatbread incorporates.
+- **DARPA (MATHBAC, I2O/DSO BAAs)** — https://www.darpa.mil/research/programs/mathbac (announcements via SAM.gov). Eligibility: US org primes. Verdict: LOW. Action: **Skip**.
+- **ARPA-H ADVOCATE / IARPA** — https://arpa-h.gov/explore-funding/programs/advocate, https://www.iarpa.gov/engage-with-us. Eligibility: org-only awards. Verdict: LOW. Action: **Skip**.
+- **DOE Genesis AI** — https://science.osti.gov/grants. Team FOAs only. Verdict: LOW. Action: **Skip**.
+- **NIST CAISI** — https://www.nist.gov/aisi. CRADA-only, no stipends. Verdict: LOW. Action: **Skip**.
+- **Horizon Europe** — https://ec.europa.eu/info/funding-tenders/opportunities/portal. US maintainers usually ineligible; paid seats EU-led. Verdict: LOW. Action: **Skip**.
+- **NGI Zero (NLnet)** — https://nlnet.nl/funding.html. Tranches across Commons/Core; EU-first. Verdict: LOW–MED. Action: **Apply** under Commons (already covered above).
+- **Mozilla Fellowships** — https://www.mozillafoundation.org/en/what-we-do/grantmaking/fellowship/. Independent track; 2026 nominations closed Jan 30. Verdict: LOW–MED. Action: **Apply if blocked status changes** — wait for next cycle.
+- **OpenAI Residency** — https://openai.com/residency. Internal hire path, not a grant. Verdict: LOW. Action: **Skip**.
+- **Anthropic Fellows** — https://alignment.anthropic.com/2025/anthropic-fellows-program-2026/. Safety/security research focus. Verdict: LOW. Action: **Skip**.
+- **Schmidt Sciences** — https://www.schmidtsciences.org/opportunities. Selective RFPs; CFR Technologist-in-Residence hosted. Verdict: LOW. Action: **Skip** unless RFP matches.
+- **Emergent Ventures (Mercatus)** — https://www.mercatus.org/emergent-ventures. Micro-grants; 501(c)(3) **not** required. Verdict: MED. Action: **Apply** — fits an individual maintainer with a clear thesis.
+- **Astera Residency** — https://astera.org/residency. On-site paid residency. Verdict: LOW–MED. Action: **Apply if blocked status changes** — relocation required.
+- **LTFF / SFF** — https://funds.effectivealtruism.org/funds/far-future, https://survivalandflourishing.fund. XR/safety thesis. Verdict: LOW. Action: **Skip** — no thesis fit.
+
+## Eligibility blockers to clear first
+
+1. **Stand up donation rails (GitHub Sponsors + Open Collective + Polar.sh).** Unblocks: Sentry FOSS Fund, thanks.dev payouts, recurring patrons, and the "shows existing community support" question that appears on STF/NLnet/Vercel forms. Lowest-cost, do this first.
+2. **Pick a fiscal sponsor (Open Source Collective, 501(c)(6), 10% fee).** Unblocks: receiving USD/EUR cash from Sentry OSS Grant, Sovereign Tech Fund, NLnet, Emergent Ventures (without personal-tax friction), and many corporate sponsorships. OSC is the fastest path; for tax-deductible US donations, consider a 501(c)(3) host instead (e.g. NumFOCUS, SPI) — at the cost of stricter scope review.
+3. **Document maintainer geography + add an EU collaborator or use-case.** Unblocks: NLnet NGI0 Commons / Core (EU-priority), Horizon-adjacent calls. Even a clearly named EU downstream user goes a long way.
+4. **Ship the relations layer + an MCP-bound demo.** Unblocks: a credible CNCF Sandbox pitch, Mistralship, Cursor OSS track, Hugging Face Space-based credits. Each of these wants a deployed artifact, not a spec.
+5. **Publish a public roadmap + funded-issue board on Polar.sh.** Unblocks: thanks.dev allocation, corporate per-issue funding, and gives reviewers a concrete budget line to fund.
+6. **Formalize maintainer entity (LLC or single-member nonprofit).** Unblocks: NSF SBIR/STTR, Microsoft for Startups investor track, Google for Startups Cloud AI. Defer until cash inflow justifies it.
+7. **Add a CONTRIBUTING.md governance + DCO/CLA section.** Unblocks: OpenJS incubation, Apache-style sponsor conversations, LF LFX Mentorship.
+
+## Stacking strategy
+
+Most of these programs are **additive** when categorized correctly:
+
+- **Credits + cash + recurring sponsorship are typically additive.** OpenAI Codex credits, Anthropic Claude Max seats, Vercel OSS hosting, Netlify/Cloudflare/Supabase free tiers, Sentry/Honeycomb/PostHog OSS plans can all run in parallel with cash grants from STF, NLnet, Sentry OSS Grant, and Emergent Ventures — none of these have exclusivity clauses against each other.
+- **Fiscal-host fees stack down, not up.** OSC (10%) is taken once on cash inflows; it does not apply to credits or seats. Plan budgets net-of-fee.
+- **Deadline-anchored programs come first.** Anthropic Claude for OSS (Jun 30 2026, hard cap 10k recipients) is the only near-term hard deadline; everything else is rolling or bi-monthly. Sequence Claude → OpenAI → Vercel → STF/NLnet/Sentry in parallel.
+- **Watch exclusivity clauses on three classes of program:**
+  1. **Equity/credit hybrids** (Microsoft for Startups investor track, Cloudflare Launchpad, Google for Startups) often require partner-VC introductions and may conflict with future fundraising terms — defer.
+  2. **CNCF Sandbox** requires IP transfer of trademark/repo to the foundation; this is irreversible. Only pursue once Flatbread is committed to a cloud-native trajectory.
+  3. **NLnet/STF reporting overlap.** Both ask for milestone reports; don't double-fund the *same* milestone — split deliverables cleanly across the two if both come in.
+- **Use OSC as the cash collector for everything.** Routing STF, NLnet, Sentry, Emergent Ventures, GitHub Sponsors corporate tiers, and Polar.sh subscriptions through one Open Collective ledger keeps reporting trivial and lets you publish a single transparent budget — which itself is a future grant qualifier.
+
+## Application backlog
+
+After the **OpenAI Codex OSS Fund** and **Anthropic Claude for OSS** drafts already in flight, queue:
+
+1. **Vercel OSS Program** — fastest-to-yes; lightweight form, ~$3.6k/yr equivalent + Starter Pack, validates "supported by reputable infra co" social proof for downstream applications.
+2. **Sovereign Tech Fund** — highest absolute cash ceiling (€50k+) with tightest thesis fit ("base technology — libs, package managers, dev tooling"); needs a 4–6 week effort to prepare maintenance plan + budget + roadmap, but the rolling intake means starting now pays off.
+3. **NLnet NGI0 Commons** — submit at the next bi-monthly deadline (Jun 1 2026); position the relations-layer-for-agents work as European NGI commons infrastructure and name an EU downstream user.
+4. **Sentry OSS Grant** — $10k cash on a 3-month cycle; trivial application once OSC fiscal hosting is set up; also unlocks thanks.dev + FOSS Fund pipeline.
+5. **Emergent Ventures (Mercatus)** — micro-grant ($5–25k typical) for an individual maintainer with a clear thesis; no 501(c)(3) required; fits "agentic coding infrastructure" framing and the application is a short essay.
+
+## Sources
+
+- https://openai.com/form/codex-open-source-fund
+- https://claude.com/open-source-max
+- https://anthropic.com/economic-futures
+- https://cloud.google.com/startup/ai
+- https://opensource.googleblog.com
+- https://foundershub.startups.microsoft.com
+- https://aws.amazon.com/startups/credits
+- https://cloudflare.com/startups/workers-launchpad
+- https://vercel.com/open-source-program
+- https://huggingface.co/docs/hub/spaces-gpus
+- https://cohere.ai/research/grants
+- https://together.ai
+- https://mistral.ai
+- https://replicate.com
+- https://cursor.com
+- https://sovereign.tech
+- https://nlnet.nl/commonsfund
+- https://nlnet.nl/core
+- https://nlnet.nl/funding.html
+- https://oscollective.org
+- https://blog.sentry.io
+- https://lfx.linuxfoundation.org
+- https://openjsf.org
+- https://thanks.dev
+- https://ngisargasso.eu
+- https://opentech.fund
+- https://mozilla.org/moss
+- https://builders.mozilla.org
+- https://mozillafoundation.org
+- https://isocfoundation.org
+- https://incubator.apache.org
+- https://chaoss.community
+- https://cncf.io
+- https://accelerator.github.com
+- https://vercel.com/startups
+- https://opensource-form.netlify.com
+- https://www.netlify.com/legal/open-source-policy
+- https://developers.cloudflare.com/workers/platform/pricing
+- https://fly.io/docs/about/open-source/
+- https://railway.com/partners
+- https://render.com/docs/free
+- https://supabase.com/pricing
+- https://www.npmjs.com
+- https://docs.github.com/en/billing/managing-billing-for-github-packages
+- https://docsearch.algolia.com
+- https://sentry.io/for/open-source
+- https://www.honeycomb.io/honeycomb-for-builders
+- https://www.datadoghq.com/partner/open-source
+- https://posthog.com/pricing
+- https://posthog.com/startups
+- https://www.notion.com/pages/nonprofits
+- https://linear.app/pricing
+- https://linear.app/startups
+- https://opencollective.com
+- https://github.com/sponsors
+- https://polar.sh
+- https://tidelift.com
+- https://seedfund.nsf.gov
+- https://www.darpa.mil/research/programs/mathbac
+- https://arpa-h.gov/explore-funding/programs/advocate
+- https://www.iarpa.gov/engage-with-us
+- https://science.osti.gov/grants
+- https://www.nist.gov/aisi
+- https://ec.europa.eu/info/funding-tenders/opportunities/portal/
+- https://www.mozillafoundation.org/en/what-we-do/grantmaking/fellowship/
+- https://openai.com/residency
+- https://alignment.anthropic.com/2025/anthropic-fellows-program-2026/
+- https://www.schmidtsciences.org/opportunities
+- https://www.mercatus.org/emergent-ventures
+- https://astera.org/residency
+- https://funds.effectivealtruism.org/funds/far-future
+- https://survivalandflourishing.fund/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two `@flatbread/proof` DAG runs produced four review-ready Markdown artifacts; a third revision DAG then compressed the roadmap and rebalanced both drafts toward audacious bets. **Nothing here is submitted** — everything is a draft for maintainer review.

## What landed

| Path | Purpose |
|---|---|
| `funding-applications/openai-open-source-fund.md` | Full Codex OSS Fund application response, form-field-mirrored, with budget table, **revised 4-phase roadmap** (foundations + Effort Graph compressed into months 1-4; audacious bets occupy months 5-12), and `> NOTE TO REVIEWER:` callouts on every UNVERIFIED form field. |
| `funding-applications/claude-for-oss-brief.md` | Sales-intake brief for Anthropic's Claude for OSS funnel — eligibility checklist, **revised monthly token-volume projection** (~80-160M input / ~16-32M output, ~2-3x prior estimate) tied to continuous preset/eval workloads, and MCP / Claude Code / HITL / evals positioning. |
| `funding-applications/REVIEW-CHECKLIST.md` | Pre-submission self-assessment with a new top-of-file revision summary, updated 1–5 scoring (technical specificity raised; evidence-of-traction due-diligence cost flagged), refreshed UNVERIFIED list, cross-draft consistency check, and recommended submission order. |
| `funding-research/funding-program-landscape.md` | Independent landscape research — TL;DR top-5 ranked table, full per-program coverage across AI-lab, foundation, infra/credits, and academic/research categories, eligibility-blocker map, stacking strategy, and ordered application backlog. |

## Audacious-bet shape adopted in both drafts

- **Phase 1 (months 1–2) — Foundations, compressed.** Typed `defineConfig`, ID normalization, relation validation, watch-mode parity — one umbrella PR train under Codex/Claude review.
- **Phase 2 (months 3–4) — Effort Graph MVP.** Conventions preset, schema-validated Append API, `flatbread-mcp` server (read + append) for Codex / Claude Code / Cursor.
- **Phase 3 (months 5–8) — Bet A: Workflow Presets for Complex Projects.** Six shipped presets — `schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation` — each a parameterized DAG over the Effort Graph + `@flatbread/proof`. Seventh slot held for a community-contributed preset by month 8.
- **Phase 4 (months 9–12) — Bets B + C in parallel.**
  - **B. HITL ergonomics.** `needsApproval` boundary on every DAG node, Claude-Code-style plan-review gate on Decision/Plan, LangGraph-style durable pause/resume keyed to a `thread_id` Session checkpoint.
  - **C. Continuous-improvement evals + research loop.** `fixture-promote` CLI, PR-time regression-replay GitHub Action, public Inspect-View-style dashboard, eval-driven preset retuning so the catalog self-tunes.

OpenAI budget rebalanced inside the published $25k cap: **Phase 3 presets ($8k, largest line)**, evals loop ($5k), HITL ($3.5k), Effort Graph + MCP ($3k), foundation Codex toil ($2.5k), docs/cookbook/contributor sponsorship ($3k).

## How it was generated

- DAG 1 (`/tmp/dag-oss-fund-drafts.json`) — 7 tasks, 3 ranks: 4 parallel research tasks → 2 parallel draft writers → 1 review-checklist task. 7/7 in 5m 59s.
- DAG 2 (`/tmp/dag-funding-research.json`) — 6 tasks, 2 ranks: 5 parallel research tasks → 1 synthesis task. 6/6 in 10m 25s.
- DAG 3 (`/tmp/dag-revise-drafts.json`, this revision) — 7 tasks, 4 ranks: 3 parallel research/state-summary tasks → 1 redesign synthesis → 2 parallel draft revisers → 1 review-checklist update. 7/7 in 25m 13s.

All three DAGs ran via `pnpm exec proof` (the `@flatbread/proof` package shipped from this repo) using the `proof` skill workflow. Live canvases were rendered to `~/.cursor/projects/workspace/canvases/` for the maintainer to scrub progress in real time.

## What the maintainer needs to do before submission

The REVIEW-CHECKLIST file consolidates the action list. High-leverage items:

1. Fill placeholders flagged in the OpenAI draft: LinkedIn URL, primary GitHub handle (org `FlatbreadLabs` vs personal), confirm `ketcham.dev@gmail.com` is the canonical contact.
2. Confirm program form-field text against the live forms (the playbooks captured the *current published* fields; OpenAI in particular updates Typeform fields without notice).
3. Confirm whether Claude for OSS permits API credits for an automated eval/preset DAG harness, or only Max-seat usage — the brief is written to accept either shape but the ask line should be tightened once known.
4. Decide whether to register a fiscal sponsor (Open Source Collective is the recommended on-ramp — it unlocks Sentry / NLnet / thanks.dev / and several rows in the landscape).
5. Stress-test the revised Claude monthly token-volume math against actual recent `@flatbread/proof` usage; the projection assumes continuous preset/eval workloads.
6. Sanity-check the Phase 3 preset list (`schema-cutover`, `release-train`, `research-compendium`, `docs-site-refactor`, `api-version-cutover`, `design-system-token-rotation`) — these names appear in *both* drafts so they must read as committed product surfaces.

## Out of scope

- No source-code changes. No test changes. No build / lint / typecheck delta — only Markdown additions and revisions under two new top-level directories.
- Applications are **not** submitted anywhere; this PR exists so the artifacts are reviewable in normal PR flow before the maintainer sends anything.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec1c088d-f614-45fd-ab61-90318e674b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec1c088d-f614-45fd-ab61-90318e674b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

