### PR TITLE
chore(dev): post-edit Prettier fix rule and pre-commit hook

### DIFF
--- a/.cursor/rules/post-edit-lint-fix.mdc
+++ b/.cursor/rules/post-edit-lint-fix.mdc
@@ -1,0 +1,22 @@
+---
+description: Fast Prettier fix after edits (matches pnpm lint)
+alwaysApply: true
+---
+
+# Post-edit lint fix
+
+After you change files in this repo (source, tests, scripts, JSON/YAML/MD that Prettier formats, config), run **one** fast formatting pass so the tree matches CI:
+
+```bash
+pnpm lint:fix:fast
+```
+
+Run it **after substantive edits** and before you commit or finish a task turn. Do not skip this in favor of only eyeballing formatting.
+
+Staged-only formatting (also run automatically by `.husky/pre-commit` when you commit):
+
+```bash
+pnpm lint:fix
+```
+
+CI still enforces `pnpm lint` (check-only). The enforced formatter is Prettier; do not rely on ESLint `--fix` unless the task is explicitly about ESLint.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd "$(dirname "$0")/.." || exit 1
+
+# Match pnpm lint (Prettier) on staged files before the commit is recorded.
+pnpm lint:fix:prettier || exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ See `CONTRIBUTING.md` for full details. Quick reference:
 - **Install**: `pnpm install`
 - **Build**: `pnpm build`
 - **Lint**: `pnpm lint` (prettier)
+- **Lint fix (after edits)**: `pnpm lint:fix:fast` (writes formatting repo-wide to match `pnpm lint`; staged-only: `pnpm lint:fix`, also runs via `.husky/pre-commit`)
 - **Typecheck**: `pnpm typecheck`
 - **Test**: `pnpm test` (builds, then runs ava + vitest suites)
 - **Full verify**: `pnpm verify` (lint + typecheck + build + test)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ pnpm build
   - Root `pnpm test` builds the workspace, runs the AVA suite configured by `ava.config.js`, then runs the package-local Vitest suites.
   - Vitest is currently used by `@flatbread/codegen` and `@flatbread/utils`.
   - Most other packages are covered by the root AVA suite or do not yet expose a package-local `test` script.
-- `pnpm lint` is the enforced Prettier formatting gate. `pnpm lint:eslint` is an optional/manual root ESLint check until the linting stack is modernized.
+- `pnpm lint` is the enforced Prettier formatting gate. After editing, run `pnpm lint:fix:fast` so formatting matches CI (Cursor agents: see `.cursor/rules/post-edit-lint-fix.mdc`). On commit, `.husky/pre-commit` runs `pnpm lint:fix` (Pretty Quick on staged files). `pnpm lint:eslint` is an optional/manual root ESLint check until the linting stack is modernized.
 - Helpful commands:
   - Local CI parity: `pnpm verify`
   - Root test suite: `pnpm test`

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:prettier": "prettier --check --plugin-search-dir=. .",
     "lint": "pnpm lint:prettier",
     "lint:fix": "pnpm lint:fix:prettier",
+    "lint:fix:fast": "prettier --write --plugin-search-dir=. .",
     "lint:fix:prettier": "pretty-quick --staged",
     "typecheck": "pnpm --filter @flatbread/proof typecheck",
     "play": "cd examples/nextjs && pnpm dev",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change encodes a fast formatting pass after edits and enforces staged Prettier on commit.

- **Cursor**: `.cursor/rules/post-edit-lint-fix.mdc` (`alwaysApply: true`) instructs agents to run `pnpm lint:fix:fast` after substantive edits.
- **Scripts**: `lint:fix:fast` runs `prettier --write` over the workspace so output matches `pnpm lint` (CI).
- **Husky**: `.husky/pre-commit` runs `pnpm lint:fix` (Pretty Quick on staged files) before each commit.
- **Docs**: `AGENTS.md` and `CONTRIBUTING.md` mention the workflow.

Note: `mergify` CLI is not available in this environment; branch was pushed with `git push`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc059594-1fb2-47f5-b892-aaf77634909e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc059594-1fb2-47f5-b892-aaf77634909e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

