### PR TITLE
fix(proof): resolve loop id collision, dedup transitive-ancestor traversal, harden tests

### DIFF
--- a/packages/flatbread/package.json
+++ b/packages/flatbread/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@types/cors": "2.8.12",
-    "@types/express": "4.17.13",
+    "@types/express": "5.0.6",
     "@types/gradient-string": "1.1.2",
     "@types/node": "16.11.47",
     "@types/sade": "1.7.4",

--- a/packages/proof/src/__tests__/loops.test.ts
+++ b/packages/proof/src/__tests__/loops.test.ts
@@ -113,7 +113,24 @@ test('parseDAG rejects two loops with the same explicit id', (t) => {
           { id: 'shared', convergeOn: 'design', maxIterations: 2 },
         ])
       ),
-    { message: /duplicate loop id/ }
+    { message: /resolved loop id.*shared.*collides/ }
+  );
+});
+
+test('parseDAG rejects loops whose resolved ids collide (explicit id matches another loop\'s default)', (t) => {
+  // Loop 0 has no explicit id: resolves to 'loop-review' via default.
+  // Loop 1 explicitly sets id: 'loop-review', convergeOn a different task.
+  // Before the fix these two loops silently produced duplicate resolved ids;
+  // after the fix parseDAG must throw.
+  t.throws(
+    () =>
+      parseDAG(
+        dagWith([
+          { convergeOn: 'review', maxIterations: 2 },
+          { id: 'loop-review', convergeOn: 'implement', maxIterations: 2 },
+        ])
+      ),
+    { message: /resolved loop id.*loop-review.*collides/ }
   );
 });
 
@@ -130,11 +147,40 @@ test('parseDAG accepts explicit reexecute.tasks inside the ancestor cone', (t) =
   const reexec = dag.loops![0].reexecute!;
   t.is(reexec.kind, 'tasks');
   if (reexec.kind === 'tasks') {
-    t.true(reexec.tasks.includes('implement'));
     // convergeOn is injected so the loop body always re-runs the
     // convergence task itself after upstream re-execution.
-    t.true(reexec.tasks.includes('review'));
+    t.deepEqual([...reexec.tasks].sort(), ['implement', 'review']);
   }
+});
+
+test('parseDAG deduplicates convergeOn from reexecute.tasks when caller includes it explicitly', (t) => {
+  const dag = parseDAG(
+    dagWith([
+      {
+        convergeOn: 'review',
+        maxIterations: 2,
+        reexecute: { kind: 'tasks', tasks: ['implement', 'review'] }, // review = convergeOn
+      },
+    ])
+  );
+  const reexec = dag.loops![0].reexecute!;
+  t.is(reexec.kind, 'tasks');
+  if (reexec.kind === 'tasks') {
+    // 'review' must appear exactly once despite being both the convergeOn and explicit in the list
+    t.deepEqual([...reexec.tasks].sort(), ['implement', 'review']);
+  }
+});
+
+test('parseDAG accepts a pause task as convergeOn (behavior: allowed, convergence semantics may be vacuous)', (t) => {
+  const raw = {
+    title: 'pause-convergeOn',
+    tasks: [
+      { id: 'gate', depends_on: [], subtask_prompt: 'wait', kind: 'pause' },
+    ],
+    loops: [{ convergeOn: 'gate', maxIterations: 1 }],
+  };
+  const dag = parseDAG(raw);
+  t.is(dag.loops![0].convergeOn, 'gate');
 });
 
 test('parseDAG rejects reexecute.tasks outside the ancestor cone', (t) => {

--- a/packages/proof/src/__tests__/loops.test.ts
+++ b/packages/proof/src/__tests__/loops.test.ts
@@ -117,7 +117,7 @@ test('parseDAG rejects two loops with the same explicit id', (t) => {
   );
 });
 
-test('parseDAG rejects loops whose resolved ids collide (explicit id matches another loop\'s default)', (t) => {
+test("parseDAG rejects loops whose resolved ids collide (explicit id matches another loop's default)", (t) => {
   // Loop 0 has no explicit id: resolves to 'loop-review' via default.
   // Loop 1 explicitly sets id: 'loop-review', convergeOn a different task.
   // Before the fix these two loops silently produced duplicate resolved ids;

--- a/packages/proof/src/converge_loop.ts
+++ b/packages/proof/src/converge_loop.ts
@@ -22,7 +22,11 @@
  * the same topological order as the original run.
  */
 
-import type { DAG, ResolvedConvergenceLoop } from './dag.js';
+import {
+  transitiveAncestorIds,
+  type DAG,
+  type ResolvedConvergenceLoop,
+} from './dag.js';
 
 export interface ConvergenceFindings {
   hasIssues: boolean;
@@ -116,21 +120,7 @@ const PLACEHOLDER_WORDS = new Set([
 ]);
 
 export function transitiveAncestors(taskId: string, dag: DAG): Set<string> {
-  const byId = new Map(dag.tasks.map((t) => [t.id, t]));
-  const visited = new Set<string>();
-  const start = byId.get(taskId);
-  if (!start) return visited;
-
-  const stack: string[] = [...start.depends_on];
-  while (stack.length > 0) {
-    const id = stack.pop()!;
-    if (visited.has(id)) continue;
-    visited.add(id);
-    const t = byId.get(id);
-    if (!t) continue;
-    for (const dep of t.depends_on) stack.push(dep);
-  }
-  return visited;
+  return transitiveAncestorIds(taskId, dag.tasks);
 }
 
 /**

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -243,11 +243,16 @@ export function parseDAG(raw: unknown): DAG {
 /**
  * Returns the closed set of transitive ancestor ids for `taskId` in the
  * given task list (the union of `depends_on` reached by repeated
- * traversal). Mirrors `transitiveAncestors` in `converge_loop.ts` but is
- * defined here so `parseDAG` can validate `loops.reexecute.tasks` without
- * a circular module import.
+ * traversal). Canonical transitive-ancestor traversal shared with
+ * `converge_loop.ts`. Defined here (takes `RawTask[]` not a full `DAG`
+ * object) so `parseDAG` can validate `loops.reexecute.tasks` without a
+ * circular module import; `converge_loop.ts:transitiveAncestors` delegates
+ * to this function.
  */
-function transitiveAncestorIds(taskId: string, tasks: RawTask[]): Set<string> {
+export function transitiveAncestorIds(
+  taskId: string,
+  tasks: RawTask[]
+): Set<string> {
   const byId = new Map(tasks.map((t) => [t.id, t]));
   const visited = new Set<string>();
   const start = byId.get(taskId);
@@ -271,7 +276,7 @@ function validateLoops(raw: unknown, tasks: RawTask[]): DAGConvergenceLoop[] {
   const taskIds = new Set(tasks.map((t) => t.id));
   const loops: DAGConvergenceLoop[] = [];
   const seenConvergeOn = new Set<string>();
-  const seenIds = new Set<string>();
+  const seenResolvedIds = new Set<string>();
   for (let i = 0; i < raw.length; i++) {
     const loop = validateLoop(raw[i], i, taskIds, tasks);
     if (seenConvergeOn.has(loop.convergeOn)) {
@@ -280,12 +285,14 @@ function validateLoops(raw: unknown, tasks: RawTask[]): DAGConvergenceLoop[] {
       );
     }
     seenConvergeOn.add(loop.convergeOn);
-    if (loop.id !== undefined) {
-      if (seenIds.has(loop.id)) {
-        throw new Error(`DAG.loops[${i}]: duplicate loop id "${loop.id}".`);
-      }
-      seenIds.add(loop.id);
+    const resolvedId = loop.id ?? `loop-${loop.convergeOn}`;
+    if (seenResolvedIds.has(resolvedId)) {
+      throw new Error(
+        `DAG.loops[${i}]: resolved loop id "${resolvedId}" collides with a previous loop's id. ` +
+          `Set an explicit \`id\` on one of the colliding loops to disambiguate.`
+      );
     }
+    seenResolvedIds.add(resolvedId);
     loops.push(loop);
   }
   return loops;

--- a/packages/proof/src/index.ts
+++ b/packages/proof/src/index.ts
@@ -40,6 +40,7 @@ export {
   resolveLoopReexecuteIds,
   transitiveAncestors,
 } from './converge_loop.js';
+export { transitiveAncestorIds } from './dag.js';
 export type { ConvergenceFindings } from './converge_loop.js';
 
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,8 +397,8 @@ importers:
         specifier: 2.8.12
         version: 2.8.12
       '@types/express':
-        specifier: 4.17.13
-        version: 4.17.13
+        specifier: 5.0.6
+        version: 5.0.6
       '@types/gradient-string':
         specifier: 1.1.2
         version: 1.1.2
@@ -3093,11 +3093,14 @@ packages:
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express@4.17.13':
-    resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==}
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
 
   '@types/express@4.17.14':
     resolution: {integrity: sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
   '@types/fs-extra@11.0.1':
     resolution: {integrity: sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==}
@@ -3221,6 +3224,9 @@ packages:
 
   '@types/serve-static@1.15.8':
     resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -11666,19 +11672,25 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
 
-  '@types/express@4.17.13':
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.18
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.5
+
+  '@types/express@4.17.14':
     dependencies:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.14.0
       '@types/serve-static': 1.15.8
 
-  '@types/express@4.17.14':
+  '@types/express@5.0.6':
     dependencies:
-      '@types/body-parser': 1.19.2
-      '@types/express-serve-static-core': 4.17.31
-      '@types/qs': 6.14.0
-      '@types/serve-static': 1.15.8
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
 
   '@types/fs-extra@11.0.1':
     dependencies:
@@ -11806,6 +11818,11 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.18
       '@types/send': 0.17.5
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.18
 
   '@types/stack-utils@2.0.3': {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the three fact-based high-severity findings from the adversarial review of #184 ([review canvas](/home/ubuntu/.cursor/projects/workspace/canvases/dag-pr184-review.canvas.tsx)).

## What changed

### 1. Resolved-id collision detection (`dag.ts`)

`validateLoops()` previously tracked duplicate loop ids with a `seenIds` Set that only recorded explicitly-set ids. Two loops could produce the same resolved id after `resolveConvergenceLoops` filled defaults (`id = 'loop-${convergeOn}'`) with no parse-time error.

**Example bug (now caught):**
```jsonc
"loops": [
  { "convergeOn": "review", "maxIterations": 2 },           // resolves to id "loop-review"
  { "id": "loop-review", "convergeOn": "impl", "maxIterations": 2 } // explicit "loop-review"
]
```

**Fix:** replace `seenIds` with `seenResolvedIds` that tracks the effective id for every loop (`loop.id ?? 'loop-${loop.convergeOn}'`). Error message names the colliding id and tells the author to add an explicit `id`.

### 2. Duplicate transitive-ancestor traversal (`dag.ts` + `converge_loop.ts`)

There were two identical iterative DFS implementations that had to be kept in sync:
- `transitiveAncestorIds(taskId, tasks: RawTask[])` in `dag.ts` (private)
- `transitiveAncestors(taskId, dag: DAG)` in `converge_loop.ts` (public export)

**Fix:**
- Export `transitiveAncestorIds` from `dag.ts` (and re-export from `index.ts`)
- Rewrite `transitiveAncestors` in `converge_loop.ts` to delegate: `return transitiveAncestorIds(taskId, dag.tasks)` — DFS body removed
- Updated JSDoc to document the canonical/delegate relationship

No behavior change; the public API signature of `transitiveAncestors` is unchanged.

### 3. Test hardening (`loops.test.ts`, 21 tests — was 18)

| Test | Change |
|---|---|
| `parseDAG accepts explicit reexecute.tasks inside the ancestor cone` | `includes` checks → `deepEqual([...tasks].sort(), ['implement', 'review'])` — catches accidental injection |
| **NEW** `parseDAG rejects loops whose resolved ids collide (explicit id matches another loop's default)` | Regression test for the collision bug (fails without fix 1) |
| **NEW** `parseDAG deduplicates convergeOn from reexecute.tasks when caller includes it explicitly` | Confirms `validateReexecute` dedup via `deepEqual` |
| **NEW** `parseDAG accepts a pause task as convergeOn (behavior: allowed, convergence semantics may be vacuous)` | Documents that pause/oracle tasks are accepted; marks the contract for future maintainers |

Also updated the error message regex in `parseDAG rejects two loops with the same explicit id` to match the new `resolved loop id … collides` message format.

### 4. `@types/express` bump (`packages/flatbread/package.json`)

`@types/express` was pinned at `4.17.13` which caused TS2769 overload errors when running `pnpm test:ava` with the updated type-check pass. Bumped to `5.0.6`.

## Testing

- ✅ `pnpm -F @flatbread/proof build`
- ✅ `pnpm exec ava packages/proof/src/__tests__/loops.test.ts` — 21/21 passing (was 18)
- ✅ `pnpm test:ava` — 73/73 passing across the workspace
- ✅ Adversarial review (Sonnet 4.6) — **APPROVE**, no blockers, no high-severity findings; convergence loop exited clean on first pass

## Does this introduce any non-backwards compatible changes?

- [ ] Yes
- [x] No

`transitiveAncestorIds` is now an additional public export (additive). All existing behavior is preserved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5ddb200-74a6-41f3-ab4f-99ad11629c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5ddb200-74a6-41f3-ab4f-99ad11629c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

