### PR TITLE
test: cover proof model selection review feedback

### DIFF
--- a/packages/proof/src/canvas_writer.ts
+++ b/packages/proof/src/canvas_writer.ts
@@ -233,6 +233,7 @@ type TaskStatus =
 type Complexity = 'HIGH' | 'MED' | 'LOW';
 type TaskKind = 'task' | 'pause' | 'oracle';
 
+// Keep in sync with ModelParameterValue / ModelSelection in dag.ts.
 interface ModelParameterValue {
   id: string;
   value: string;

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -1,0 +1,104 @@
+import test from 'ava';
+
+import {
+  resolveModelSelectionFromCatalog,
+  type ModelCatalogItem,
+  type ModelSelection,
+} from './dag';
+
+function resolveSelection(
+  selection: ModelSelection,
+  variants: NonNullable<ModelCatalogItem['variants']>
+): ModelSelection {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2', variants },
+  ];
+  return resolveModelSelectionFromCatalog(selection, catalog, 'test model');
+}
+
+test('resolveModelSelectionFromCatalog prefers highest-scoring variant among matches', (t) => {
+  const resolved = resolveSelection(
+    { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+    [
+      {
+        displayName: 'Default medium concise',
+        isDefault: true,
+        params: [
+          { id: 'effort', value: 'medium' },
+          { id: 'style', value: 'concise' },
+        ],
+      },
+      {
+        displayName: 'Max concise',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'concise' },
+        ],
+      },
+      {
+        displayName: 'Max verbose',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'verbose' },
+        ],
+      },
+    ]
+  );
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [
+      { id: 'effort', value: 'max' },
+      { id: 'style', value: 'concise' },
+    ],
+  });
+});
+
+test('resolveModelSelectionFromCatalog breaks equal-score ties to catalog default variant', (t) => {
+  const resolved = resolveSelection(
+    { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+    [
+      {
+        displayName: 'Max with style override',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'verbose' },
+        ],
+      },
+      {
+        displayName: 'Default max',
+        isDefault: true,
+        params: [{ id: 'effort', value: 'max' }],
+      },
+    ]
+  );
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'max' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog throws a descriptive error when no variant matches', (t) => {
+  const err = t.throws(() =>
+    resolveSelection(
+      { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+      [
+        {
+          displayName: 'Default medium',
+          isDefault: true,
+          params: [{ id: 'effort', value: 'medium' }],
+        },
+      ]
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected no-match variant selection to throw.');
+    return;
+  }
+  t.regex(
+    err.message,
+    /does not match any Cursor SDK preset variant\. Valid variants:/
+  );
+});

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -102,3 +102,50 @@ test('resolveModelSelectionFromCatalog throws a descriptive error when no varian
     /does not match any Cursor SDK preset variant\. Valid variants:/
   );
 });
+
+test('resolveModelSelectionFromCatalog returns default variant when no params requested', (t) => {
+  const resolved = resolveSelection({ id: 'composer-2' }, [
+    {
+      displayName: 'Fast',
+      params: [{ id: 'effort', value: 'low' }],
+    },
+    {
+      displayName: 'Default',
+      isDefault: true,
+      params: [{ id: 'effort', value: 'medium' }],
+    },
+  ]);
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'medium' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog throws on unknown model id', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2' },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog({ id: 'unknown-model' }, catalog, 'test')
+  );
+
+  if (!err) {
+    t.fail('Expected unknown model id to throw.');
+    return;
+  }
+  t.regex(err.message, /uses unknown Cursor SDK model/);
+});
+
+test('resolveModelSelectionFromCatalog passes through selection when model has no variants', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2' },
+  ];
+  const selection: ModelSelection = {
+    id: 'composer-2',
+  };
+  const resolved = resolveModelSelectionFromCatalog(selection, catalog, 'test');
+
+  t.deepEqual(resolved, selection);
+  t.not(resolved, selection);
+});

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -1,8 +1,10 @@
 import test from 'ava';
 
 import {
+  normalizeModelSelection,
   resolveModelSelectionFromCatalog,
   type ModelCatalogItem,
+  type ModelSpec,
   type ModelSelection,
 } from './dag.js';
 
@@ -122,6 +124,79 @@ test('resolveModelSelectionFromCatalog returns default variant when no params re
   });
 });
 
+test('resolveModelSelectionFromCatalog falls back to first variant when no default is flagged', (t) => {
+  const resolved = resolveSelection({ id: 'composer-2' }, [
+    {
+      displayName: 'Fast',
+      params: [{ id: 'effort', value: 'low' }],
+    },
+    {
+      displayName: 'Careful',
+      params: [{ id: 'effort', value: 'high' }],
+    },
+  ]);
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'low' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog treats empty params as no params requested', (t) => {
+  const resolved = resolveSelection({ id: 'composer-2', params: [] }, [
+    {
+      displayName: 'Fast',
+      params: [{ id: 'effort', value: 'low' }],
+    },
+    {
+      displayName: 'Default',
+      isDefault: true,
+      params: [{ id: 'effort', value: 'medium' }],
+    },
+  ]);
+
+  t.deepEqual(resolved, {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'medium' }],
+  });
+});
+
+test('resolveModelSelectionFromCatalog throws when no variant fully matches requested params', (t) => {
+  const err = t.throws(() =>
+    resolveSelection(
+      {
+        id: 'composer-2',
+        params: [
+          { id: 'effort', value: 'max' },
+          { id: 'style', value: 'verbose' },
+        ],
+      },
+      [
+        {
+          displayName: 'Max concise',
+          params: [
+            { id: 'effort', value: 'max' },
+            { id: 'style', value: 'concise' },
+          ],
+        },
+        {
+          displayName: 'Medium verbose',
+          params: [
+            { id: 'effort', value: 'medium' },
+            { id: 'style', value: 'verbose' },
+          ],
+        },
+      ]
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected partial variant match to throw.');
+    return;
+  }
+  t.regex(err.message, /does not match any Cursor SDK preset variant/);
+});
+
 test('resolveModelSelectionFromCatalog throws on unknown model id', (t) => {
   const catalog: ModelCatalogItem[] = [
     { id: 'composer-2', displayName: 'Composer 2' },
@@ -148,4 +223,131 @@ test('resolveModelSelectionFromCatalog passes through selection when model has n
 
   t.deepEqual(resolved, selection);
   t.not(resolved, selection);
+});
+
+test('resolveModelSelectionFromCatalog accepts valid params declared by catalog parameters', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    {
+      id: 'composer-2',
+      displayName: 'Composer 2',
+      parameters: [
+        {
+          id: 'effort',
+          values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
+        },
+      ],
+    },
+  ];
+  const selection: ModelSelection = {
+    id: 'composer-2',
+    params: [{ id: 'effort', value: 'high' }],
+  };
+
+  const resolved = resolveModelSelectionFromCatalog(selection, catalog, 'test');
+
+  t.deepEqual(resolved, selection);
+  t.not(resolved, selection);
+});
+
+test('resolveModelSelectionFromCatalog throws when catalog parameters reject a param id', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    {
+      id: 'composer-2',
+      displayName: 'Composer 2',
+      parameters: [{ id: 'effort', values: [{ value: 'medium' }] }],
+    },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog(
+      { id: 'composer-2', params: [{ id: 'style', value: 'concise' }] },
+      catalog,
+      'test'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected unknown parameter id to throw.');
+    return;
+  }
+  t.regex(err.message, /does not support param "style"/);
+});
+
+test('resolveModelSelectionFromCatalog throws when catalog parameters reject a param value', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    {
+      id: 'composer-2',
+      displayName: 'Composer 2',
+      parameters: [{ id: 'effort', values: [{ value: 'medium' }] }],
+    },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog(
+      { id: 'composer-2', params: [{ id: 'effort', value: 'max' }] },
+      catalog,
+      'test'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected unsupported parameter value to throw.');
+    return;
+  }
+  t.regex(err.message, /param "effort" does not support value "max"/);
+});
+
+test('resolveModelSelectionFromCatalog throws when explicit params have no catalog declaration', (t) => {
+  const catalog: ModelCatalogItem[] = [
+    { id: 'composer-2', displayName: 'Composer 2' },
+  ];
+  const err = t.throws(() =>
+    resolveModelSelectionFromCatalog(
+      { id: 'composer-2', params: [{ id: 'effort', value: 'medium' }] },
+      catalog,
+      'test'
+    )
+  );
+
+  if (!err) {
+    t.fail('Expected undeclared parameters to throw.');
+    return;
+  }
+  t.regex(err.message, /does not declare parameters or preset variants/);
+});
+
+test('normalizeModelSelection trims string model ids', (t) => {
+  t.deepEqual(normalizeModelSelection('  composer-2  '), { id: 'composer-2' });
+});
+
+test('normalizeModelSelection throws label-prefixed errors for invalid model specs', (t) => {
+  for (const raw of ['', '   ', 42, null]) {
+    const err = t.throws(() =>
+      normalizeModelSelection(raw as unknown as ModelSpec, 'test model')
+    );
+
+    if (!err) {
+      t.fail(`Expected invalid model spec ${String(raw)} to throw.`);
+      continue;
+    }
+    t.regex(err.message, /^test model must be /);
+  }
+});
+
+test('normalizeModelSelection throws label-prefixed errors for invalid param values', (t) => {
+  for (const value of ['', '   ', 42]) {
+    const err = t.throws(() =>
+      normalizeModelSelection(
+        {
+          id: 'composer-2',
+          params: [{ id: 'effort', value }],
+        } as unknown as ModelSpec,
+        'test model'
+      )
+    );
+
+    if (!err) {
+      t.fail(`Expected invalid param value ${String(value)} to throw.`);
+      continue;
+    }
+    t.is(err.message, 'test model.params[0].value must be a non-empty string.');
+  }
 });

--- a/packages/proof/src/dag.test.ts
+++ b/packages/proof/src/dag.test.ts
@@ -4,7 +4,7 @@ import {
   resolveModelSelectionFromCatalog,
   type ModelCatalogItem,
   type ModelSelection,
-} from './dag';
+} from './dag.js';
 
 function resolveSelection(
   selection: ModelSelection,

--- a/packages/proof/src/dag.ts
+++ b/packages/proof/src/dag.ts
@@ -550,7 +550,7 @@ export function validateModelSelection(
   label = 'model'
 ): ModelSelection {
   const obj = validateModelSelectionObject(raw, label);
-  const id = validateModelId(obj.id, `${label}.id`);
+  const id = validateNonEmptyString(obj.id, `${label}.id`);
   const params = validateModelParams(obj.params, label);
   return createModelSelection(id, params);
 }
@@ -565,7 +565,7 @@ function validateModelSelectionObject(
   return raw as Record<string, unknown>;
 }
 
-function validateModelId(raw: unknown, label: string): string {
+function validateNonEmptyString(raw: unknown, label: string): string {
   if (typeof raw !== 'string' || raw.trim() === '') {
     throw new Error(`${label} must be a non-empty string.`);
   }
@@ -605,8 +605,11 @@ function validateModelParam(
   }
   const param = raw as Record<string, unknown>;
   return {
-    id: validateModelId(param.id, `${label}.params[${index}].id`),
-    value: validateModelId(param.value, `${label}.params[${index}].value`),
+    id: validateNonEmptyString(param.id, `${label}.params[${index}].id`),
+    value: validateNonEmptyString(
+      param.value,
+      `${label}.params[${index}].value`
+    ),
   };
 }
 
@@ -615,7 +618,7 @@ export function normalizeModelSelection(
   label = 'model'
 ): ModelSelection {
   if (typeof raw === 'string') {
-    return createModelSelection(validateModelId(raw, label));
+    return createModelSelection(validateNonEmptyString(raw, label));
   }
   return validateModelSelection(raw, label);
 }

--- a/packages/proof/src/run_dag.ts
+++ b/packages/proof/src/run_dag.ts
@@ -475,6 +475,8 @@ function isResumeTerminalStatus(status: TaskState['status']): boolean {
 function taskModelSelection(ts: TaskState): ModelSelection {
   return (
     ts.modelSelection ??
+    // Fallback path is for legacy persisted run-state (before modelSelection).
+    // In that shape ts.model is always a plain model id (not formatted output).
     normalizeModelSelection(ts.model, `task ${ts.id} model`)
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary of changes**

- Addressed PR #178 review feedback by clarifying legacy fallback invariants in `run_dag`, renaming a generic validation helper in `dag`, adding tie-break/no-match resolver tests, and documenting sync expectations in the canvas template type block.
- Extended AVA coverage for `resolveModelSelectionFromCatalog` to include all requested uncovered branches:
  - zero-requested-params path selects the catalog default variant,
  - unknown model id throws `uses unknown Cursor SDK model`,
  - no-variants path returns a cloned passthrough selection.

Closes #

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
- [x] My changes generate no new console errors locally
- [x] If applicable, try to include a test that fails without this PR but passes with it

### Does this introduce any non-backwards compatible changes?

- [ ] Yes
- [x] No

### Does this include any user config changes?

- [ ] Yes
  - [ ] If so, I have updated the relevant areas of documentation
- [x] No
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a21aed-1994-4ca1-b136-1fa6ab9b808a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a21aed-1994-4ca1-b136-1fa6ab9b808a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

