### PR TITLE
refactor(config): loadConfig returns an initialized LoadedFlatbreadConfig

### DIFF
--- a/packages/codegen/src/cli.ts
+++ b/packages/codegen/src/cli.ts
@@ -1,4 +1,4 @@
-import { generateSchema, type LoadedFlatbreadConfig } from '@flatbread/core';
+import { generateSchema } from '@flatbread/core';
 import { loadConfig } from '@flatbread/config';
 import kleur from 'kleur';
 import type { CodegenOptions } from './types.js';
@@ -63,14 +63,7 @@ export function createCodegenCommand() {
         cwd: options.config ? dirname(options.config) : process.cwd(),
       });
 
-      if (!configResult.config) {
-        console.error(kleur.red('✗ Failed to load Flatbread configuration'));
-        process.exit(1);
-      }
-
-      // Initialize the configuration first
-      const { initializeConfig } = await import('@flatbread/core');
-      const loadedConfig = initializeConfig(configResult.config);
+      const loadedConfig = configResult.config!;
 
       // Generate GraphQL schema
       if (options.verbose) {

--- a/packages/codegen/src/generator.ts
+++ b/packages/codegen/src/generator.ts
@@ -669,11 +669,10 @@ export async function watchAndGenerate(
       if (path.includes('flatbread.config.')) {
         try {
           const { loadConfig } = await import('@flatbread/config');
-          const { initializeConfig } = await import('@flatbread/core');
           const configResult = await loadConfig({ cwd: process.cwd() });
 
           if (configResult.config) {
-            currentConfig = initializeConfig(configResult.config);
+            currentConfig = configResult.config;
             console.log(kleur.dim('🔧 Configuration reloaded'));
             // Refresh codegen options from the updated config so changes like outputFile/outputDir/documents are applied
             currentOptions = deriveOptionsFromConfig(

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -1,0 +1,70 @@
+import test from 'ava';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { LoadedFlatbreadConfig } from '@flatbread/core';
+import { NoConfigFoundError, TooManyConfigsFoundError } from './errors';
+import { loadConfig } from './load';
+
+async function withTempConfig(
+  files: Record<string, string>,
+  callback: (cwd: string) => Promise<void>
+) {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'flatbread-config-'));
+
+  try {
+    await Promise.all(
+      Object.entries(files).map(([filename, contents]) =>
+        fs.writeFile(path.join(cwd, filename), contents)
+      )
+    );
+    await callback(cwd);
+  } finally {
+    await fs.rm(cwd, { recursive: true, force: true });
+  }
+}
+
+test('loadConfig throws NoConfigFoundError without exiting', async (t) => {
+  await withTempConfig({}, async (cwd) => {
+    const error = await t.throwsAsync(loadConfig({ cwd }));
+
+    t.true(error instanceof NoConfigFoundError);
+  });
+});
+
+test('loadConfig throws TooManyConfigsFoundError without exiting', async (t) => {
+  await withTempConfig(
+    {
+      'flatbread.config.js': 'export default {};',
+      'flatbread.config.ts': 'export default {};',
+    },
+    async (cwd) => {
+      const error = await t.throwsAsync(loadConfig({ cwd }));
+
+      t.true(error instanceof TooManyConfigsFoundError);
+    }
+  );
+});
+
+test('loadConfig returns an initialized config', async (t) => {
+  await withTempConfig(
+    {
+      'flatbread.config.js': `
+        export default {
+          source: { fetch: async () => ({}) },
+          transformer: { extensions: ['.md'], inspect: (input) => String(input) },
+          content: [],
+        };
+      `,
+    },
+    async (cwd) => {
+      const result = await loadConfig({ cwd });
+      const config = result.config as LoadedFlatbreadConfig;
+
+      t.is(result.filepath, path.join(cwd, 'flatbread.config.js'));
+      t.is(config.transformer.length, 1);
+      t.deepEqual(config.loaded.extensions, ['.md']);
+      t.is(typeof config.fieldNameTransform, 'function');
+    }
+  );
+});

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -1,6 +1,7 @@
 import {
   ConfigResult,
   FlatbreadConfig,
+  LoadedFlatbreadConfig,
   initializeConfig,
 } from '@flatbread/core';
 import { build } from 'esbuild';
@@ -62,7 +63,7 @@ async function loadConfigFromBundledFile(
  * @returns Promise that resolves to the user config object.
  */
 export async function loadConfig({ cwd = process.cwd() } = {}): Promise<
-  ConfigResult<FlatbreadConfig>
+  ConfigResult<LoadedFlatbreadConfig>
 > {
   let configFileName: ConfigFileName;
   const files = await fs.readdir(cwd);

--- a/packages/flatbread/src/utils/getSchema.ts
+++ b/packages/flatbread/src/utils/getSchema.ts
@@ -29,6 +29,5 @@ export async function loadFlatbreadConfig(
   const { loadConfig } = await import('@flatbread/config');
   const result = await loadConfig({ cwd });
   if (!result.config) throw new Error('Flatbread configuration was not found');
-  const { initializeConfig } = await import('@flatbread/core');
-  return { ...result, config: initializeConfig(result.config) };
+  return result;
 }


### PR DESCRIPTION
Make the config package the single owner of "a loaded, initialized
config". loadConfig already called initializeConfig internally, but its
return type claimed raw FlatbreadConfig, so downstream callers
defensively re-initialized: codegen's CLI, watchAndGenerate's
config-reload branch, and flatbread's loadFlatbreadConfig each ran a
second initializeConfig over an already-initialized config.

- loadConfig now returns ConfigResult<LoadedFlatbreadConfig>; the three
  redundant re-inits are deleted.
- initializeConfig has exactly two call sites: the loader and
  FlatbreadProvider (the programmatic entry point that accepts raw
  config from user code).
- Typed load errors (NoConfigFoundError, TooManyConfigsFoundError)
  surface without process exit; process.exit stays only in CLI wrappers.

Test plan: new AVA unit tests in packages/config cover both error modes
and assert a successful load returns an initialized (normalized) config.
Full suite green: pnpm verify (lint + typecheck + build + 243 AVA + 52
vitest).

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #207