### PR TITLE
chore(merge-queue): exempt owner-authored PRs from review gate

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,50 @@
+# Keep the normal review requirement for contributors while allowing the
+# repository owner to use the same required CI through Mergify's queue.
+shared:
+  required_ci: &required_ci
+    - check-success = build (20.x, ubuntu-latest)
+    - check-success = build (22.x, ubuntu-latest)
+    - check-success = integration-nextjs (20.x, macos-latest)
+    - check-success = integration-nextjs (20.x, ubuntu-latest)
+    - check-success = integration-nextjs (20.x, windows-latest)
+    - check-success = integration-nextjs (22.x, macos-latest)
+    - check-success = integration-nextjs (22.x, ubuntu-latest)
+    - check-success = integration-nextjs (22.x, windows-latest)
+    - check-success = integration-sveltekit (20.x, macos-latest)
+    - check-success = integration-sveltekit (20.x, ubuntu-latest)
+    - check-success = integration-sveltekit (20.x, windows-latest)
+    - check-success = integration-sveltekit (22.x, macos-latest)
+    - check-success = integration-sveltekit (22.x, ubuntu-latest)
+    - check-success = integration-sveltekit (22.x, windows-latest)
+    - check-success = lint (20.x, ubuntu-latest)
+    - check-success = lint (22.x, ubuntu-latest)
+    - check-success = test (20.x, ubuntu-latest)
+    - check-success = test (22.x, ubuntu-latest)
+
+queue_rules:
+  - name: owner-bypass
+    queue_conditions:
+      - author = tonyketcham
+      - check-success = build (20.x, ubuntu-latest)
+      - check-success = build (22.x, ubuntu-latest)
+      - check-success = integration-nextjs (20.x, macos-latest)
+      - check-success = integration-nextjs (20.x, ubuntu-latest)
+      - check-success = integration-nextjs (20.x, windows-latest)
+      - check-success = integration-nextjs (22.x, macos-latest)
+      - check-success = integration-nextjs (22.x, ubuntu-latest)
+      - check-success = integration-nextjs (22.x, windows-latest)
+      - check-success = integration-sveltekit (20.x, macos-latest)
+      - check-success = integration-sveltekit (20.x, ubuntu-latest)
+      - check-success = integration-sveltekit (20.x, windows-latest)
+      - check-success = integration-sveltekit (22.x, macos-latest)
+      - check-success = integration-sveltekit (22.x, ubuntu-latest)
+      - check-success = integration-sveltekit (22.x, windows-latest)
+      - check-success = lint (20.x, ubuntu-latest)
+      - check-success = lint (22.x, ubuntu-latest)
+      - check-success = test (20.x, ubuntu-latest)
+      - check-success = test (22.x, ubuntu-latest)
+    merge_conditions: *required_ci
+    branch_protection_injection_mode: none
+
+  - name: default
+    branch_protection_injection_mode: queue


### PR DESCRIPTION
Keep all required CI checks mandatory for owner-authored PRs while preserving
GitHub review enforcement for contributors through the default queue rule.

Co-authored-by: Cursor <cursoragent@cursor.com>