### PR TITLE
fix(merge-queue): configure owner queue merge account

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,7 @@ shared:
 
 queue_rules:
   - name: owner-bypass
+    merge_bot_account: tonyketcham
     queue_conditions:
       - author = tonyketcham
       - check-success = build (20.x, ubuntu-latest)


### PR DESCRIPTION
Provide the merge bot account required when the owner queue bypasses branch
protection injection while retaining the explicit CI conditions.

Co-authored-by: Cursor <cursoragent@cursor.com>