### PR TITLE
docs(effort-graph): accept Blob as citeable longform payload

### DIFF
--- a/.flatbread-efforts/decisions/dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve.md
+++ b/.flatbread-efforts/decisions/dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve.md
@@ -1,0 +1,39 @@
+---
+id: dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Name citeable longform payloads Blob
+state: accepted
+created_at: '2026-07-19T10:48:32.005Z'
+derives_from:
+  - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
+---
+
+## Context
+
+Crumb Graph primitives (Effort, Issue, Finding, Decision, Constraint, Risk) are epistemic and deliberately bounded. Longform plans, research troves, JSON dumps, and media do not fit record bodies or digest caps, and Artifact/Plan were intentional non-models in v1. Agents and humans still need a place to put bulky, experimental content in git (or another Flatbread source) and cite it from a short Finding or Decision.
+
+## Decision
+
+Adopt **Blob** as the name for a citeable, non-epistemic payload collection that Crumb Graph records can reference.
+
+A Blob is opaque content of any format (markdown, JSON, images, etc.). It has no proposed/accepted lifecycle — it is storage, not judgment. Epistemic records stay short and point at Blobs via refs (e.g. `derives_from` / evidence-style edges).
+
+Blobs are ordinary Flatbread content: they may live in the filesystem source or in another source plugin (S3, CDN, file host, …). The graph stores ids/refs; the configured source resolves bytes.
+
+## Alternatives considered
+
+- **Bread-themed names (Annex, Loaf, Sheet, Bannock, Grist, …):** Brand-fun but obscure; agents and humans need an obvious noun first.
+- **File:** Obvious for disk, misleading when the collection is backed by S3/CDN.
+- **Artifact / Asset / Document:** Generic SaaS; also collides with CLI write-result `artifacts` and digest `artifact_path`.
+- **Keep stuffing longform into Finding/Decision bodies:** Rejected — fights digest caps and bounded recall.
+
+## Consequences
+
+- Glossary intentional non-models must drop or rewrite Artifact once Blob ships (Blob is the citeable payload; Artifact remains a non-model for run/build outputs).
+- Preset, mutations, skills, and digests need an additive Blob surface; bounded reads must not inline Blob bodies by default.
+- Multi-source Blob backing is in scope for the design, even if filesystem-first lands first.
+- Brand poetry can wait; clarity for agents wins.
+
+## Reversal criteria
+
+Revisit if Blob confuses with binary-only storage, if a clearer storage-agnostic noun wins dogfood, or if treating payloads as ordinary untyped content refs (no Blob collection) proves sufficient.

--- a/.flatbread-efforts/issues/iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z.md
+++ b/.flatbread-efforts/issues/iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z.md
@@ -1,0 +1,28 @@
+---
+id: iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Implement Blob collection and Crumb Graph cites
+kind: gap
+status: open
+created_at: '2026-07-19T10:48:48.349Z'
+derives_from:
+  - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
+  - dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve
+---
+
+Implement the accepted Blob decision so Crumb Graph records can cite longform/dynamic payloads.
+
+## Scope
+
+- Add a **Blob** content collection (non-epistemic; no proposed/accepted lifecycle).
+- Allow Blobs to be backed by ordinary Flatbread sources (filesystem first; design for S3/CDN/other source plugins).
+- Let Findings, Decisions, Issues (and other primitives as needed) ref Blob ids; keep epistemic bodies short.
+- Bounded reads: digests cite Blob id/title/locator — do not inline Blob bodies by default.
+- Update glossary (intentional non-models), preset/skills/CLI/mutations as needed; keep the mutation enum deliberately small (additive only with clear semantics).
+- Dogfood: at least one Finding that cites a Blob (e.g. research markdown or JSON dump).
+
+## Out of scope for first slice
+
+- Full binary/media CMS features
+- Renaming CLI write-result `artifacts` / digest `artifact_path`
+- Bread-themed product rename of Blob


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary of changes**

Record an accepted Effort Graph Decision to name citeable, non-epistemic longform payloads **Blob**, and open an Issue to implement the Blob collection plus Crumb Graph cites.

Blobs are opaque content (markdown, JSON, images, etc.) with no proposed/accepted lifecycle. They are ordinary Flatbread content and may be backed by the filesystem or another source plugin (S3, CDN, file host). Epistemic records stay short and reference Blob ids; bounded digests should not inline Blob bodies by default.

- Decision: `dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve` (accepted)
- Issue: `iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z` (open)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
- [x] My changes generate no new console errors locally
- [ ] If applicable, try to include a test that fails without this PR but passes with it

### Does this introduce any non-backwards compatible changes?

- [ ] Yes
- [x] No

### Does this include any user config changes?

- [ ] Yes
  - [ ] If so, I have updated the relevant areas of documentation
- [x] No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f79d1-0359-7f07-8151-d1983ae5989d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f79d1-0359-7f07-8151-d1983ae5989d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

