### PR TITLE
fix(effort-graph): clarify Citation and Blob behavior

### DIFF
--- a/.agents/skills/effort-graph/SKILL.md
+++ b/.agents/skills/effort-graph/SKILL.md
@@ -5,13 +5,14 @@ description: Journal reasoning (decisions, findings, issues, constraints, risks,
 
 # Effort Graph — agent journaling and recall
 
-The Effort Graph is persistent, queryable memory for long-horizon work, stored
-as markdown records in the repo. Eight collections/primitives: epistemic
-**Effort**, **Issue**, **Finding**, **Decision**, **Constraint**, and
-**Risk**, plus non-epistemic **Citation** and **Blob**. Every record belongs
-to exactly one Effort. You write through 15 typed mutations and read through
-5 bounded queries — never by hand-editing record frontmatter (bodies may be
-edited freely).
+The Effort Graph stores durable project memory as markdown records in the
+repository. It has eight record types: **Effort**, **Issue**, **Finding**,
+**Decision**, **Constraint**, and **Risk** capture the work and reasoning;
+**Citation** stores a source or reference; and **Blob** stores attached
+content such as a document, JSON, or image. Every record belongs to one
+Effort. Create and update records through 15 typed mutations, and read them
+through 5 bounded queries. Do not hand-edit record frontmatter, although you
+may edit record bodies freely.
 
 Read [glossary.md](./glossary.md) for the primitive and edge semantics before
 inventing a new record kind or relation.
@@ -73,10 +74,11 @@ Critical semantics:
   unless you deliberately want the competing proposals closed.
 - Edges are forward-only in payloads (`derives_from`, `supersedes`,
   `invalidates`); back-edges are materialized automatically.
-- Cites: `WriteCitation` (body may be a URL; optional `blob` + `role`), then
-  `cites: ["<cit-id>"]` on any epistemic create. Flatbread `refs` link
-  records → Citation → optional Blob. Bounded digests omit Blob bodies —
-  use `effort get`.
+- External sources: create a `WriteCitation` record (its body may be a URL,
+  with optional `blob` and `role` fields), then add
+  `cites: ["<cit-id>"]` when creating an Issue, Finding, Decision,
+  Constraint, or Risk. A Citation may point to a Blob for attached content.
+  Bounded digests omit Blob bodies; use `effort get <blob-id>` to read one.
 - When superseding, open the new record's body with a short rollup of what
   changed and why — reads render ancestors only as one-line checkpoints.
 - For a hard-to-reverse, surprising decision made after a real trade-off, use
@@ -152,12 +154,12 @@ server-side.
    for the full body. Reserve opening `.flatbread-efforts/**/*.md` for rare
    cases (e.g. digest byte-cap miss on an oversized record), not normal
    zoom-in.
-3. **During work:** if the source artifact needs capture, teach Blob first with
-   `WriteBlob`; then create the source with `WriteCitation`; then do the
-   epistemic write using `cites: ["<cit-id>"]`. There is no cite retro-link
-   mutation, so create the Citation before the Finding/Decision/Constraint/Risk
-   that should cite it. Open Issues for real gaps/blockers, and record
-   Decisions with `derives_from` citing the Findings, Constraints, and Issues
+3. **During work:** when outside material supports a record, save large
+   content with `WriteBlob` if needed, then create a `WriteCitation`, then
+   create the Issue, Finding, Decision, Constraint, or Risk with
+   `cites: ["<cit-id>"]`. You cannot add a citation later, so create the
+   Citation first. Open Issues for real gaps or blockers, and use
+   `derives_from` on Decisions to link the Findings, Constraints, and Issues
    they respond to.
 4. **On commitment:** `AcceptDecision` (mind `rejectSiblings`), `ResolveIssue`
    with `resolvedBy` citing the closing Decision/Findings.

--- a/.agents/skills/effort-graph/SKILL.md
+++ b/.agents/skills/effort-graph/SKILL.md
@@ -77,8 +77,10 @@ Critical semantics:
 - External sources: create a `WriteCitation` record (its body may be a URL,
   with optional `blob` and `role` fields), then add
   `cites: ["<cit-id>"]` when creating an Issue, Finding, Decision,
-  Constraint, or Risk. A Citation may point to a Blob for attached content.
-  Bounded digests omit Blob bodies; use `effort get <blob-id>` to read one.
+  Constraint, or Risk. Both the Citation in `cites` and the Blob in
+  `Citation.blob` must belong to the same Effort as the record that links to
+  them. Bounded digests omit Blob bodies; use `effort get <blob-id>` to read
+  one.
 - When superseding, open the new record's body with a short rollup of what
   changed and why — reads render ancestors only as one-line checkpoints.
 - For a hard-to-reverse, surprising decision made after a real trade-off, use

--- a/.agents/skills/effort-graph/SKILL.md
+++ b/.agents/skills/effort-graph/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: effort-graph
-description: Journal reasoning (decisions, findings, issues, constraints, risks) into a Flatbread Effort Graph and recall it with bounded reads. Use when starting or resuming a thread of work, recording a decision or finding, resolving an issue, checking what is blocking or still open on an effort, or when the user mentions effort graph, journaling, blocking decisions, or agent memory.
+description: Journal reasoning (decisions, findings, issues, constraints, risks, citations, blobs) into a Flatbread Effort Graph and recall it with bounded reads. Use when starting or resuming a thread of work, recording a decision or finding, resolving an issue, checking what is blocking or still open on an effort, or when the user mentions effort graph, journaling, blocking decisions, agent memory, citation, blob, cites, longform, WriteCitation, or WriteBlob.
 ---
 
 # Effort Graph — agent journaling and recall
 
 The Effort Graph is persistent, queryable memory for long-horizon work, stored
-as markdown records in the repo. Six primitives: **Effort** (the anchor thread
-of work), **Issue**, **Finding**, **Decision**, **Constraint**, **Risk**.
-Every record belongs to exactly one Effort. You write through 13 typed
-mutations and read through 5 bounded queries — never by hand-editing record
-frontmatter (bodies may be edited freely).
+as markdown records in the repo. Eight collections/primitives: epistemic
+**Effort**, **Issue**, **Finding**, **Decision**, **Constraint**, and
+**Risk**, plus non-epistemic **Citation** and **Blob**. Every record belongs
+to exactly one Effort. You write through 15 typed mutations and read through
+5 bounded queries — never by hand-editing record frontmatter (bodies may be
+edited freely).
 
 Read [glossary.md](./glossary.md) for the primitive and edge semantics before
 inventing a new record kind or relation.
@@ -43,7 +44,7 @@ export default defineConfig({
 });
 ```
 
-Records live under `<root>/{efforts,issues,findings,decisions,constraints,risks}/`.
+Records live under `<root>/{efforts,issues,findings,decisions,constraints,risks,citations,blobs}/`.
 The write journal is `<root>/.journal/`; read digests cache under
 `.flatbread/effort-graph/read-cache/` (both gitignored).
 
@@ -151,9 +152,13 @@ server-side.
    for the full body. Reserve opening `.flatbread-efforts/**/*.md` for rare
    cases (e.g. digest byte-cap miss on an oversized record), not normal
    zoom-in.
-3. **During work:** journal Findings as evidence lands; open Issues for real
-   gaps/blockers; record Decisions with `derives_from` citing the Findings,
-   Constraints, and Issues they respond to.
+3. **During work:** if the source artifact needs capture, teach Blob first with
+   `WriteBlob`; then create the source with `WriteCitation`; then do the
+   epistemic write using `cites: ["<cit-id>"]`. There is no cite retro-link
+   mutation, so create the Citation before the Finding/Decision/Constraint/Risk
+   that should cite it. Open Issues for real gaps/blockers, and record
+   Decisions with `derives_from` citing the Findings, Constraints, and Issues
+   they respond to.
 4. **On commitment:** `AcceptDecision` (mind `rejectSiblings`), `ResolveIssue`
    with `resolvedBy` citing the closing Decision/Findings.
 5. Maintenance: `flatbread effort cache prune` deletes digests older than

--- a/.agents/skills/effort-graph/glossary.md
+++ b/.agents/skills/effort-graph/glossary.md
@@ -74,9 +74,8 @@ writer-materialized reverse projections.
 
 `cites` links an Issue, Finding, Decision, Constraint, or Risk to a Citation.
 It accepts Citation ids only, never Blob ids. A Citation may optionally point
-to a Blob. `flatbread effort relations` follows `cites` links, but does not
-follow Blob attachments; use `flatbread effort get <blob-id>` to read an
-attachment.
+to a Blob. Both links must stay within the same Effort. `flatbread effort relations` follows `cites` links, but does not follow Blob attachments; use
+`flatbread effort get <blob-id>` to read an attachment.
 
 New edge vocabulary needs a dogfooded query the existing vocabulary cannot
 express.

--- a/.agents/skills/effort-graph/glossary.md
+++ b/.agents/skills/effort-graph/glossary.md
@@ -50,21 +50,20 @@ accepted.
 
 ### Citation
 
-A first-class cite target that explains what evidence is and how it relates.
-Epistemic records point at Citations via the homogeneous `cites` ref so
-Flatbread validates and GraphQL-resolves the edge. A Citation body alone is
-valid — often a URL string. An optional `blob` ref attaches a longform/opaque
-payload when needed. Optional `role` labels the relationship (e.g. evidence,
-context). Citations have no proposed/accepted lifecycle.
+A record for an external source or reference. Issues, Findings, Decisions,
+Constraints, and Risks link to Citations through `cites`. A Citation body can
+be only a URL. Its optional `blob` field attaches stored content when needed,
+and its optional `role` describes the relationship (for example, `evidence`
+or `context`). Citations do not have a proposed/accepted lifecycle.
 
 ### Blob
 
-A citeable, non-epistemic payload: opaque content of any format (markdown,
-JSON, images, etc.) with no proposed/accepted lifecycle. Blobs are ordinary
-Flatbread content (filesystem-first; other sources such as S3/CDN may back
-them later). Records do not cite Blobs directly — they cite a Citation that
-may optionally ref a Blob. Bounded digests omit Blob bodies by default; use
-`effort get <blob-id>` to read the payload.
+Stored content of any format (markdown, JSON, images, and more). Blobs do not
+have a proposed/accepted lifecycle. They are ordinary Flatbread content:
+filesystem-backed today, with other sources such as S3 or a CDN possible
+later. Records do not cite Blobs directly. Instead, they cite a Citation,
+which may optionally point to a Blob. Bounded digests omit Blob bodies by
+default; use `effort get <blob-id>` to read the content.
 
 ## Edges
 
@@ -73,10 +72,11 @@ record of the same primitive, while `invalidates` says a record was wrong.
 Those forward edges are authoritative; `superseded_by` and `invalidated_by` are
 writer-materialized reverse projections.
 
-`cites` is a homogeneous Flatbread `refs` edge to Citation on every epistemic
-record (Effort, Issue, Finding, Decision, Constraint, Risk). Citation may
-optionally `blob` → Blob. Bounded `effort relations` walks `cites` but not
-`blob`; zoom with `effort get`.
+`cites` links an Issue, Finding, Decision, Constraint, or Risk to a Citation.
+It accepts Citation ids only, never Blob ids. A Citation may optionally point
+to a Blob. `flatbread effort relations` follows `cites` links, but does not
+follow Blob attachments; use `flatbread effort get <blob-id>` to read an
+attachment.
 
 New edge vocabulary needs a dogfooded query the existing vocabulary cannot
 express.

--- a/.agents/skills/effort-graph/glossary.md
+++ b/.agents/skills/effort-graph/glossary.md
@@ -75,7 +75,8 @@ writer-materialized reverse projections.
 
 `cites` is a homogeneous Flatbread `refs` edge to Citation on every epistemic
 record (Effort, Issue, Finding, Decision, Constraint, Risk). Citation may
-optionally `blob` → Blob.
+optionally `blob` → Blob. Bounded `effort relations` walks `cites` but not
+`blob`; zoom with `effort get`.
 
 New edge vocabulary needs a dogfooded query the existing vocabulary cannot
 express.

--- a/.agents/skills/effort-graph/reference.md
+++ b/.agents/skills/effort-graph/reference.md
@@ -19,14 +19,15 @@ on all creates except `CreateEffort`, `WriteCitation`, and `WriteBlob`:
 `derives_from[]`, `supersedes[]`, `invalidates[]` (arrays of existing ids;
 targets are validated).
 
-Optional `cites[]` on all epistemic creates (`CreateEffort` and every `Write*`
-except `WriteCitation` / `WriteBlob`): existing **Citation** ids (homogeneous
-Flatbread `refs` → Citation).
+Optional `cites[]` on epistemic creates (every `Write*` except `WriteCitation`
+/ `WriteBlob`): existing **Citation** ids in the **same effort** (homogeneous
+Flatbread `refs` → Citation). Create Citations first, then cite them from
+Findings, Decisions, Issues, etc. — `CreateEffort` does not take `cites`.
 
 ### Effort lifecycle
 
 ```json
-{"type":"CreateEffort","title":"...","body":"...","slug":"optional","cites":["<cit-id>"]}
+{"type":"CreateEffort","title":"...","body":"...","slug":"optional"}
 {"type":"SetEffortStatus","effortId":"<eff-id>","status":"active|paused|completed|abandoned"}
 ```
 
@@ -131,7 +132,8 @@ flatbread effort cache prune
 ```
 
 - `--kinds`: `effort|issue|finding|decision|constraint|risk|citation|blob`
-  (records: default all non-effort kinds, including `citation` and `blob`).
+  (records: default all non-effort kinds including `citation`; `blob` is
+  opt-in via `--kinds`).
 - `list --status`: defaults to `active`; valid values are exactly `active`,
   `paused`, `completed`, and `abandoned`. Values are ORed and results are
   ordered by `created_at` ascending, then `id`.

--- a/.agents/skills/effort-graph/reference.md
+++ b/.agents/skills/effort-graph/reference.md
@@ -47,7 +47,8 @@ Initial states: Issue `status: open`; Decision `state: proposed`; Risk
 `state: open`. Citation and Blob have no lifecycle state.
 
 A Citation body alone is valid (commonly a URL). `blob` is optional; use it
-only when you need to attach stored content such as a document or JSON.
+only when you need to attach stored content such as a document or JSON. When
+provided, `blob` must be the id of a Blob in the same Effort as the Citation.
 
 ### Add links between existing records
 

--- a/.agents/skills/effort-graph/reference.md
+++ b/.agents/skills/effort-graph/reference.md
@@ -19,10 +19,10 @@ on all creates except `CreateEffort`, `WriteCitation`, and `WriteBlob`:
 `derives_from[]`, `supersedes[]`, `invalidates[]` (arrays of existing ids;
 targets are validated).
 
-Optional `cites[]` on epistemic creates (every `Write*` except `WriteCitation`
-/ `WriteBlob`): existing **Citation** ids in the **same effort** (homogeneous
-Flatbread `refs` → Citation). Create Citations first, then cite them from
-Findings, Decisions, Issues, etc. — `CreateEffort` does not take `cites`.
+Optional `cites[]` on Issue, Finding, Decision, Constraint, and Risk creates:
+existing **Citation** ids in the **same Effort**. Create Citations first, then
+add their ids when creating Findings, Decisions, Issues, and other records.
+`CreateEffort` does not accept `cites`.
 
 ### Effort lifecycle
 
@@ -46,10 +46,10 @@ Findings, Decisions, Issues, etc. — `CreateEffort` does not take `cites`.
 Initial states: Issue `status: open`; Decision `state: proposed`; Risk
 `state: open`. Citation and Blob have no lifecycle state.
 
-A Citation body alone is valid (commonly a URL). `blob` is optional — attach
-a Blob only when you need a longform/opaque payload behind the cite.
+A Citation body alone is valid (commonly a URL). `blob` is optional; use it
+only when you need to attach stored content such as a document or JSON.
 
-### Edge retro-linking (records must already exist)
+### Add links between existing records
 
 ```json
 {"type":"Supersede","supersederId":"<id>","targetId":"<same-kind-id>"}
@@ -131,9 +131,9 @@ flatbread effort blocking-decisions <effortId> [consistency flags]
 flatbread effort cache prune
 ```
 
-- `--kinds`: `effort|issue|finding|decision|constraint|risk|citation|blob`
-  (records: default all non-effort kinds including `citation`; `blob` is
-  opt-in via `--kinds`).
+- `--kinds`: `effort|issue|finding|decision|constraint|risk|citation|blob`.
+  `records` includes every non-Effort kind except Blob by default. Add
+  `--kinds blob` when you need Blob records.
 - `list --status`: defaults to `active`; valid values are exactly `active`,
   `paused`, `completed`, and `abandoned`. Values are ORed and results are
   ordered by `created_at` ascending, then `id`.

--- a/.agents/skills/effort-modeling/DECISION-BODY.md
+++ b/.agents/skills/effort-modeling/DECISION-BODY.md
@@ -25,10 +25,11 @@ What becomes easier, harder, required, or intentionally deferred?
 What evidence would justify revisiting this?
 ```
 
-The body belongs to the Decision record. Wire epistemic upstream through
-`derives_from` when creating it — the Findings, Constraints, Risks, and Issues
-this Decision responds to or weighs.
+The body belongs to the Decision record. When creating it, use
+`derives_from` to link the Findings, Constraints, Risks, and Issues the
+Decision responds to or weighs.
 
-For external evidence (URLs, docs, longform captures), do not paste the source
-into the body. Use `WriteBlob` when the payload is longform, then
-`WriteCitation`, then pass `cites: ["<cit-id>"]` on the Decision create.
+For external evidence (URLs, documents, or saved content), do not paste the
+source into the body. If needed, save the content with `WriteBlob`, then
+create a `WriteCitation`, then pass `cites: ["<cit-id>"]` when creating the
+Decision.

--- a/.agents/skills/effort-modeling/DECISION-BODY.md
+++ b/.agents/skills/effort-modeling/DECISION-BODY.md
@@ -25,5 +25,10 @@ What becomes easier, harder, required, or intentionally deferred?
 What evidence would justify revisiting this?
 ```
 
-The body belongs to the Decision record. Cite related Findings, Constraints,
-Risks, and Issues through `derives_from` when creating it.
+The body belongs to the Decision record. Wire epistemic upstream through
+`derives_from` when creating it — the Findings, Constraints, Risks, and Issues
+this Decision responds to or weighs.
+
+For external evidence (URLs, docs, longform captures), do not paste the source
+into the body. Use `WriteBlob` when the payload is longform, then
+`WriteCitation`, then pass `cites: ["<cit-id>"]` on the Decision create.

--- a/.agents/skills/effort-modeling/SKILL.md
+++ b/.agents/skills/effort-modeling/SKILL.md
@@ -44,32 +44,30 @@ Use `flatbread effort write` for the current Effort, following
 - **Risk** — a prospective negative outcome with likelihood and severity.
 - **Decision** — a proposed or accepted commitment among alternatives.
 
-### Three ways to "cite"
+### Two kinds of links
 
-Do not conflate these:
+Use these links for different purposes:
 
-- **Vernacular "cite"** — ordinary language for pointing at evidence.
-- **`cites`** — typed Flatbread `refs` edge from an epistemic record to a
-  **Citation** (external URL, doc, or longform capture). Records never cite
-  Blobs directly.
-- **`derives_from`** — causal upstream **epistemic** context: the Findings,
-  Constraints, Risks, and Issues this record responds to or weighs.
+- **`cites`** — links a record to a **Citation** for an external URL,
+  document, or saved source. Records never cite Blobs directly.
+- **`derives_from`** — links a record to the Findings, Constraints, Risks,
+  and Issues that informed it.
 
-A Decision typically `derives_from` the epistemic records it synthesizes and
-`cites` Citations for outside sources.
+A Decision typically uses `derives_from` for project reasoning and `cites` for
+outside sources.
 
 ### External evidence (URL or longform)
 
-When a Finding, Decision, Constraint, or Risk rests on external evidence, journal
-it as a Citation — do not duplicate the source in the epistemic body:
+When a Finding, Decision, Constraint, or Risk rests on an external source,
+create a Citation instead of copying the source into the record body:
 
-1. **`WriteBlob`** — only when the source is longform or opaque content that
-   needs capture (markdown, JSON, image, etc.).
+1. **`WriteBlob`** — only when you need to save large or non-text content
+   (markdown, JSON, an image, and so on).
 2. **`WriteCitation`** — body is often the URL string; pass optional `blob` and
    `role` when needed.
-3. **Epistemic write** — pass `cites: ["<cit-id>"]` on the create. There is no
-   cite retro-link mutation, so create the Citation before the record that
-   should cite it.
+3. **Create the record** — pass `cites: ["<cit-id>"]` when creating the
+   Finding, Decision, Constraint, or Risk. You cannot add a citation later,
+   so create the Citation first.
 
 Record a Decision when it is hard to reverse, surprising without context, and
 the result of a real trade-off. Create it as proposed while the user is still

--- a/.agents/skills/effort-modeling/SKILL.md
+++ b/.agents/skills/effort-modeling/SKILL.md
@@ -44,6 +44,33 @@ Use `flatbread effort write` for the current Effort, following
 - **Risk** — a prospective negative outcome with likelihood and severity.
 - **Decision** — a proposed or accepted commitment among alternatives.
 
+### Three ways to "cite"
+
+Do not conflate these:
+
+- **Vernacular "cite"** — ordinary language for pointing at evidence.
+- **`cites`** — typed Flatbread `refs` edge from an epistemic record to a
+  **Citation** (external URL, doc, or longform capture). Records never cite
+  Blobs directly.
+- **`derives_from`** — causal upstream **epistemic** context: the Findings,
+  Constraints, Risks, and Issues this record responds to or weighs.
+
+A Decision typically `derives_from` the epistemic records it synthesizes and
+`cites` Citations for outside sources.
+
+### External evidence (URL or longform)
+
+When a Finding, Decision, Constraint, or Risk rests on external evidence, journal
+it as a Citation — do not duplicate the source in the epistemic body:
+
+1. **`WriteBlob`** — only when the source is longform or opaque content that
+   needs capture (markdown, JSON, image, etc.).
+2. **`WriteCitation`** — body is often the URL string; pass optional `blob` and
+   `role` when needed.
+3. **Epistemic write** — pass `cites: ["<cit-id>"]` on the create. There is no
+   cite retro-link mutation, so create the Citation before the record that
+   should cite it.
+
 Record a Decision when it is hard to reverse, surprising without context, and
 the result of a real trade-off. Create it as proposed while the user is still
 deciding; call `AcceptDecision` only after they commit. Always pass

--- a/.agents/skills/grill-with-efforts/SKILL.md
+++ b/.agents/skills/grill-with-efforts/SKILL.md
@@ -14,9 +14,9 @@ and resolve dependent choices in order. Explore the codebase for facts, but
 leave choices to the user. Do not implement the plan until shared understanding
 is confirmed.
 
-When external evidence informs a choice, journal it through the Citation
-workflow (`WriteBlob` if longform → `WriteCitation` → epistemic write with
-`cites`) rather than pasting URLs or longform into epistemic bodies. Use
-`derives_from` for in-graph epistemic upstream; typed `cites` are for
-Citation records only — see effort-modeling for vernacular cite vs `cites` vs
-`derives_from`.
+When an external source informs a choice, create a `WriteCitation` record
+instead of pasting the source into another record. Save large content first
+with `WriteBlob` when needed, then create the Citation, then create the
+Finding or Decision with `cites`. Use `derives_from` to link Findings, Issues,
+Constraints, and Risks within the project; use `cites` only for Citation
+records. See effort-modeling for details.

--- a/.agents/skills/grill-with-efforts/SKILL.md
+++ b/.agents/skills/grill-with-efforts/SKILL.md
@@ -13,3 +13,10 @@ Offer a recommended answer for each decision, wait for the user's response,
 and resolve dependent choices in order. Explore the codebase for facts, but
 leave choices to the user. Do not implement the plan until shared understanding
 is confirmed.
+
+When external evidence informs a choice, journal it through the Citation
+workflow (`WriteBlob` if longform → `WriteCitation` → epistemic write with
+`cites`) rather than pasting URLs or longform into epistemic bodies. Use
+`derives_from` for in-graph epistemic upstream; typed `cites` are for
+Citation records only — see effort-modeling for vernacular cite vs `cites` vs
+`derives_from`.

--- a/.flatbread-efforts/constraints/con-mutation-enum-stays-deliberately-small--02k06bxbjwrjfp9x.md
+++ b/.flatbread-efforts/constraints/con-mutation-enum-stays-deliberately-small--02k06bxbjwrjfp9x.md
@@ -1,24 +1,28 @@
 ---
-id: con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
+id: con-mutation-enum-stays-deliberately-small--02k06bxbjwrjfp9x
 effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
 title: Mutation enum stays deliberately small
 kind: hard
-created_at: '2026-07-18T19:42:47.759Z'
+created_at: '2026-07-24T08:08:23.938Z'
 derives_from:
-  - dec-use-semantic-mutations-and-a-standalone-writer--2d0m3tkqhad4yyhr
-superseded_by:
-  - con-mutation-enum-stays-deliberately-small--02k06bxbjwrjfp9x
+  - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
+  - fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq
+supersedes:
+  - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
 ---
 
-V1 has exactly thirteen named mutations. Every operation has a Zod schema,
+V1 has exactly fifteen named mutations. Every operation has a Zod schema,
 validates against a committed index generation, and owns a defined semantic
 transition.
 
 The surface consists of Effort lifecycle (`CreateEffort`, `SetEffortStatus`);
 one creation mutation for each primitive (`WriteIssue`, `WriteFinding`,
-`WriteDecision`, `WriteConstraint`, `WriteRisk`); edge retro-linking
-(`Supersede`, `Invalidate`); and lifecycle transitions (`ResolveIssue`,
-`AcceptDecision`, `MitigateRisk`, `SetRiskState`).
+`WriteDecision`, `WriteConstraint`, `WriteRisk`, `WriteCitation`, `WriteBlob`);
+edge retro-linking (`Supersede`, `Invalidate`); and lifecycle transitions
+(`ResolveIssue`, `AcceptDecision`, `MitigateRisk`, `SetRiskState`).
+
+`WriteCitation` and `WriteBlob` have no lifecycle state — Citation body alone
+is valid (e.g. URL); optional `blob` ref attaches longform payloads.
 
 No generic frontmatter patch, delete/archive operation, standalone
 `RejectDecision`, or body-edit mutation is part of v1. Git is the undo story;

--- a/.flatbread-efforts/decisions/dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve.md
+++ b/.flatbread-efforts/decisions/dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve.md
@@ -8,17 +8,30 @@ derives_from:
   - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
 ---
 
-Rollup: cite mechanism clarified by dec-ship-citation-collection-with-optional-blob — epistemic records use `cites`→Citation (optional `blob`→Blob on the Citation); direct Blob cites and derives_from/evidence-style Blob refs are not the v1 model.
+Update: records use `cites[]` to link to Citations. A Citation can optionally
+point to a Blob that stores large content. Records cannot cite Blobs directly,
+and Blobs are not used with `derives_from` or evidence links in the first
+release.
 
 ## Context
 
-Crumb Graph primitives (Effort, Issue, Finding, Decision, Constraint, Risk) are epistemic and deliberately bounded. Longform plans, research troves, JSON dumps, and media do not fit record bodies or digest caps, and Artifact/Plan were intentional non-models in v1. Agents and humans still need a place to put bulky, experimental content in git (or another Flatbread source) and cite it from a short Finding or Decision.
+Crumb Graph records (Effort, Issue, Finding, Decision, Constraint, and Risk)
+capture work and reasoning in deliberately small records. Long plans, research
+material, JSON dumps, and media do not fit well in record bodies or digest
+limits. Artifact and Plan are not record types in the first release. Agents
+and humans still need a place to store large, experimental content in git (or
+another Flatbread source) and link to it from a Finding or Decision.
 
 ## Decision
 
-Adopt **Blob** as the name for a citeable, non-epistemic payload collection that Crumb Graph records reach via Citation indirection.
+Adopt **Blob** as the name for a collection of stored content that Crumb Graph
+records reach through Citations.
 
-A Blob is opaque content of any format (markdown, JSON, images, etc.). It has no proposed/accepted lifecycle — it is storage, not judgment. Epistemic records stay short and cite **Citation** ids in `cites[]`; a Citation body alone is valid (e.g. URL), and optional `blob`→Blob attaches longform payloads.
+A Blob stores content of any format (markdown, JSON, images, and more). It has
+no proposed/accepted lifecycle because it is storage, not a judgment. Records
+stay short and cite **Citation** ids in `cites[]`. A Citation body alone is
+valid (for example, a URL), and its optional `blob` field attaches saved
+content.
 
 Blobs are ordinary Flatbread content: they may live in the filesystem source or in another source plugin (S3, CDN, file host, …). The graph stores ids/refs; the configured source resolves bytes.
 

--- a/.flatbread-efforts/decisions/dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve.md
+++ b/.flatbread-efforts/decisions/dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve.md
@@ -8,15 +8,17 @@ derives_from:
   - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
 ---
 
+Rollup: cite mechanism clarified by dec-ship-citation-collection-with-optional-blob — epistemic records use `cites`→Citation (optional `blob`→Blob on the Citation); direct Blob cites and derives_from/evidence-style Blob refs are not the v1 model.
+
 ## Context
 
 Crumb Graph primitives (Effort, Issue, Finding, Decision, Constraint, Risk) are epistemic and deliberately bounded. Longform plans, research troves, JSON dumps, and media do not fit record bodies or digest caps, and Artifact/Plan were intentional non-models in v1. Agents and humans still need a place to put bulky, experimental content in git (or another Flatbread source) and cite it from a short Finding or Decision.
 
 ## Decision
 
-Adopt **Blob** as the name for a citeable, non-epistemic payload collection that Crumb Graph records can reference.
+Adopt **Blob** as the name for a citeable, non-epistemic payload collection that Crumb Graph records reach via Citation indirection.
 
-A Blob is opaque content of any format (markdown, JSON, images, etc.). It has no proposed/accepted lifecycle — it is storage, not judgment. Epistemic records stay short and point at Blobs via refs (e.g. `derives_from` / evidence-style edges).
+A Blob is opaque content of any format (markdown, JSON, images, etc.). It has no proposed/accepted lifecycle — it is storage, not judgment. Epistemic records stay short and cite **Citation** ids in `cites[]`; a Citation body alone is valid (e.g. URL), and optional `blob`→Blob attaches longform payloads.
 
 Blobs are ordinary Flatbread content: they may live in the filesystem source or in another source plugin (S3, CDN, file host, …). The graph stores ids/refs; the configured source resolves bytes.
 

--- a/.flatbread-efforts/findings/fnd-accepted-decisions-disagree-on-how-blobs-are-cit--z9s360sgahmtjz7h.md
+++ b/.flatbread-efforts/findings/fnd-accepted-decisions-disagree-on-how-blobs-are-cit--z9s360sgahmtjz7h.md
@@ -1,0 +1,13 @@
+---
+id: fnd-accepted-decisions-disagree-on-how-blobs-are-cit--z9s360sgahmtjz7h
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Accepted Decisions disagree on how Blobs are cited
+kind: survey
+created_at: '2026-07-24T07:43:58.885Z'
+derives_from:
+  - dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve
+  - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
+  - iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z
+---
+
+dec-name-citeable-longform-payloads-blob (accepted, #224) says epistemic records point at Blobs via derives_from / evidence-style edges. dec-ship-citation-collection-with-optional-blob (accepted, #225) ships cites→Citation (optional blob→Blob) and forbids direct Blob cites. The shipping Decision does not supersede the cite-mechanism part of the naming Decision. Resolved Issue iss-implement-blob-collection-and-crumb-graph-cites still scopes ref Blob ids and Finding that cites a Blob. Graph memory currently teaches two models.

--- a/.flatbread-efforts/findings/fnd-accepted-decisions-disagree-on-how-blobs-are-cit--z9s360sgahmtjz7h.md
+++ b/.flatbread-efforts/findings/fnd-accepted-decisions-disagree-on-how-blobs-are-cit--z9s360sgahmtjz7h.md
@@ -8,6 +8,8 @@ derives_from:
   - dec-name-citeable-longform-payloads-blob--9b11q14fgsx2ytve
   - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
   - iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z
+invalidated_by:
+  - fnd-citation-and-blob-records-now-match-the-current--p6c37v29mx4jjfr2
 ---
 
 dec-name-citeable-longform-payloads-blob (accepted, #224) says epistemic records point at Blobs via derives_from / evidence-style edges. dec-ship-citation-collection-with-optional-blob (accepted, #225) ships cites→Citation (optional blob→Blob) and forbids direct Blob cites. The shipping Decision does not supersede the cite-mechanism part of the naming Decision. Resolved Issue iss-implement-blob-collection-and-crumb-graph-cites still scopes ref Blob ids and Finding that cites a Blob. Graph memory currently teaches two models.

--- a/.flatbread-efforts/findings/fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz.md
+++ b/.flatbread-efforts/findings/fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz.md
@@ -6,6 +6,8 @@ kind: retrospective
 created_at: '2026-07-26T02:38:53.500Z'
 invalidates:
   - fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh
+invalidated_by:
+  - fnd-citation-and-blob-records-now-match-the-current--p6c37v29mx4jjfr2
 ---
 
 The Citation and Blob implementation now rejects cross-Effort `cites` and `Citation.blob` links. `CreateEffort` rejects `cites`, and relation reads accept an Effort as their own root record. This Finding replaces the earlier report of missing validation.

--- a/.flatbread-efforts/findings/fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz.md
+++ b/.flatbread-efforts/findings/fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz.md
@@ -1,0 +1,11 @@
+---
+id: fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Citation and Blob links now stay within one Effort
+kind: retrospective
+created_at: '2026-07-26T02:38:53.500Z'
+invalidates:
+  - fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh
+---
+
+The Citation and Blob implementation now rejects cross-Effort `cites` and `Citation.blob` links. `CreateEffort` rejects `cites`, and relation reads accept an Effort as their own root record. This Finding replaces the earlier report of missing validation.

--- a/.flatbread-efforts/findings/fnd-citation-and-blob-records-now-match-the-current--p6c37v29mx4jjfr2.md
+++ b/.flatbread-efforts/findings/fnd-citation-and-blob-records-now-match-the-current--p6c37v29mx4jjfr2.md
@@ -1,0 +1,13 @@
+---
+id: fnd-citation-and-blob-records-now-match-the-current--p6c37v29mx4jjfr2
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Citation and Blob records now match the current model
+kind: retrospective
+created_at: '2026-07-26T02:49:33.761Z'
+invalidates:
+  - fnd-accepted-decisions-disagree-on-how-blobs-are-cit--z9s360sgahmtjz7h
+  - fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz
+  - fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq
+---
+
+The skills and related Decision, Issue, and Constraint now describe eight record types, fifteen mutations, and the Citation-to-optional-Blob path. Direct Blob citations are not supported. Cross-Effort `cites` and `Citation.blob` links are rejected. `CreateEffort` rejects `cites` when callers use the CLI or mutation schema; planner and writer enforcement remains a follow-up so programmatic callers cannot silently drop the field. This Finding replaces the prior audits and retrospective where their earlier claims no longer match the current contract.

--- a/.flatbread-efforts/findings/fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh.md
+++ b/.flatbread-efforts/findings/fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh.md
@@ -8,6 +8,8 @@ kind: measurement
 created_at: '2026-07-24T07:44:00.313Z'
 derives_from:
   - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
+invalidated_by:
+  - fnd-citation-and-blob-links-now-stay-within-one-effo--gkyd4dczafebk4fz
 ---
 
 Planner validates cites/Citation.blob target kind only, unlike ResolveIssue/MitigateRisk/SetRiskState which enforce same effort. Cross-effort Citation/Blob links are writable. Read path silently drops foreign-effort cite targets in relations() with no anomaly. Separately, Effort records have no effort frontmatter field, so relations(effortId, effortId, [cites]) rejects the Effort as not in effort. CreateEffort.cites also chicken-eggs: Citations require an existing Effort, so same-effort CreateEffort.cites is unreachable via the mutation API.

--- a/.flatbread-efforts/findings/fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh.md
+++ b/.flatbread-efforts/findings/fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh.md
@@ -1,0 +1,13 @@
+---
+id: fnd-cites-and-citation-blob-skip-same-effort-checks--pts8c8ar72vaevvh
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: >-
+  cites and Citation.blob skip same-effort checks; Effort.cites is mostly
+  unreachable
+kind: measurement
+created_at: '2026-07-24T07:44:00.313Z'
+derives_from:
+  - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
+---
+
+Planner validates cites/Citation.blob target kind only, unlike ResolveIssue/MitigateRisk/SetRiskState which enforce same effort. Cross-effort Citation/Blob links are writable. Read path silently drops foreign-effort cite targets in relations() with no anomaly. Separately, Effort records have no effort frontmatter field, so relations(effortId, effortId, [cites]) rejects the Effort as not in effort. CreateEffort.cites also chicken-eggs: Citations require an existing Effort, so same-effort CreateEffort.cites is unreachable via the mutation API.

--- a/.flatbread-efforts/findings/fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq.md
+++ b/.flatbread-efforts/findings/fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq.md
@@ -1,0 +1,12 @@
+---
+id: fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Skill and hard Constraint still teach 13 mutations / 6 primitives
+kind: survey
+created_at: '2026-07-24T07:43:57.479Z'
+derives_from:
+  - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
+  - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
+---
+
+Stack tip ships Citation+Blob (8 collections, WriteCitation+WriteBlob ⇒ 15 mutations), but skill opener still says Six primitives / 13 typed mutations and omits citations/blobs from record paths (later in the same file it says 15). Hard Constraint con-mutation-enum-stays-deliberately-small still asserts exactly thirteen named mutations and lists only the pre-Citation surface. Additive mutations are allowed with dogfood evidence — dogfood exists — but the Constraint body was never updated/superseded. Agents that trust the skill hero or Constraint will miss the new surface.

--- a/.flatbread-efforts/findings/fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq.md
+++ b/.flatbread-efforts/findings/fnd-skill-and-hard-constraint-still-teach-13-mutatio--gvg2btns0q7rp0eq.md
@@ -7,6 +7,8 @@ created_at: '2026-07-24T07:43:57.479Z'
 derives_from:
   - con-mutation-enum-stays-deliberately-small--45v1ae3neq26g1rz
   - dec-ship-citation-collection-with-optional-blob--fyga3x876n7rcnmn
+invalidated_by:
+  - fnd-citation-and-blob-records-now-match-the-current--p6c37v29mx4jjfr2
 ---
 
 Stack tip ships Citation+Blob (8 collections, WriteCitation+WriteBlob ⇒ 15 mutations), but skill opener still says Six primitives / 13 typed mutations and omits citations/blobs from record paths (later in the same file it says 15). Hard Constraint con-mutation-enum-stays-deliberately-small still asserts exactly thirteen named mutations and lists only the pre-Citation surface. Additive mutations are allowed with dogfood evidence — dogfood exists — but the Constraint body was never updated/superseded. Agents that trust the skill hero or Constraint will miss the new surface.

--- a/.flatbread-efforts/issues/iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z.md
+++ b/.flatbread-efforts/issues/iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z.md
@@ -13,16 +13,17 @@ resolved_by:
   - fnd-citation-collection-keeps-flatbread-refs-intact--z33ar5vyjxzr7ys0
 ---
 
-Implement the accepted Blob decision so Crumb Graph records can cite longform/dynamic payloads.
+Implement the accepted Blob decision so Crumb Graph records can cite longform/dynamic payloads via Citation indirection.
 
 ## Scope
 
 - Add a **Blob** content collection (non-epistemic; no proposed/accepted lifecycle).
+- Add a **Citation** collection; epistemic records use `cites`→Citation (optional `blob`→Blob on the Citation).
 - Allow Blobs to be backed by ordinary Flatbread sources (filesystem first; design for S3/CDN/other source plugins).
-- Let Findings, Decisions, Issues (and other primitives as needed) ref Blob ids; keep epistemic bodies short.
-- Bounded reads: digests cite Blob id/title/locator — do not inline Blob bodies by default.
+- Keep epistemic bodies short; attach longform via Citation→Blob, not direct Blob refs.
+- Bounded reads: digests cite Citation id/title/locator and omit Blob bodies by default.
 - Update glossary (intentional non-models), preset/skills/CLI/mutations as needed; keep the mutation enum deliberately small (additive only with clear semantics).
-- Dogfood: at least one Finding that cites a Blob (e.g. research markdown or JSON dump).
+- Dogfood: at least one Finding that cites a Citation (with optional Blob payload).
 
 ## Out of scope for first slice
 

--- a/.flatbread-efforts/issues/iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z.md
+++ b/.flatbread-efforts/issues/iss-implement-blob-collection-and-crumb-graph-cites--g2c7m6j39we5xy3z.md
@@ -13,15 +13,19 @@ resolved_by:
   - fnd-citation-collection-keeps-flatbread-refs-intact--z33ar5vyjxzr7ys0
 ---
 
-Implement the accepted Blob decision so Crumb Graph records can cite longform/dynamic payloads via Citation indirection.
+Implement the accepted Blob decision so Crumb Graph records can refer to large
+or changing content through Citations.
 
 ## Scope
 
-- Add a **Blob** content collection (non-epistemic; no proposed/accepted lifecycle).
-- Add a **Citation** collection; epistemic records use `cites`→Citation (optional `blob`→Blob on the Citation).
+- Add a **Blob** content collection with no proposed/accepted lifecycle.
+- Add a **Citation** collection. Records use `cites` to link to a Citation,
+  which may optionally point to a Blob.
 - Allow Blobs to be backed by ordinary Flatbread sources (filesystem first; design for S3/CDN/other source plugins).
-- Keep epistemic bodies short; attach longform via Citation→Blob, not direct Blob refs.
-- Bounded reads: digests cite Citation id/title/locator and omit Blob bodies by default.
+- Keep record bodies short; attach large content through Citation → Blob, not
+  direct Blob references.
+- Bounded reads: show a Citation's id, title, and location in digests, while
+  omitting Blob bodies by default.
 - Update glossary (intentional non-models), preset/skills/CLI/mutations as needed; keep the mutation enum deliberately small (additive only with clear semantics).
 - Dogfood: at least one Finding that cites a Citation (with optional Blob payload).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,31 @@
 # Agents
 
+## Plain-language output
+
+Apply this style to every written output: chat responses, plans, PR titles and
+descriptions, commit messages, documentation, and code comments. Write for
+readers who understand software but are new to Flatbread and the change at
+hand.
+
+- Lead with what changed, why it matters, or what the reader should do.
+- Prefer short, concrete sentences with a clear subject and action.
+- Explain a Flatbread-specific term the first time it appears. Keep exact API,
+  CLI, field, and record names in code formatting.
+- Describe behavior directly: say what creates, links, stores, reads, or
+  validates what.
+- Present multi-step workflows as ordered steps.
+
+Avoid unexplained internal shorthand and abstract labels such as `epistemic`,
+`homogeneous refs`, `retro-link`, `roll up`, `dogfood`, `hero`, `surface`, and
+`stack`. Use one only when technical accuracy requires it, and define it in
+the same sentence.
+
+Before delivering written output, confirm that a reader can answer:
+
+1. What changed?
+2. What does each named thing do?
+3. What action should they take, and in what order?
+
 ## Cursor Cloud specific instructions
 
 ### Overview

--- a/packages/effort-graph/skills/effort-graph/SKILL.md
+++ b/packages/effort-graph/skills/effort-graph/SKILL.md
@@ -5,13 +5,14 @@ description: Journal reasoning (decisions, findings, issues, constraints, risks,
 
 # Effort Graph — agent journaling and recall
 
-The Effort Graph is persistent, queryable memory for long-horizon work, stored
-as markdown records in the repo. Eight collections/primitives: epistemic
-**Effort**, **Issue**, **Finding**, **Decision**, **Constraint**, and
-**Risk**, plus non-epistemic **Citation** and **Blob**. Every record belongs
-to exactly one Effort. You write through 15 typed mutations and read through
-5 bounded queries — never by hand-editing record frontmatter (bodies may be
-edited freely).
+The Effort Graph stores durable project memory as markdown records in the
+repository. It has eight record types: **Effort**, **Issue**, **Finding**,
+**Decision**, **Constraint**, and **Risk** capture the work and reasoning;
+**Citation** stores a source or reference; and **Blob** stores attached
+content such as a document, JSON, or image. Every record belongs to one
+Effort. Create and update records through 15 typed mutations, and read them
+through 5 bounded queries. Do not hand-edit record frontmatter, although you
+may edit record bodies freely.
 
 Read [glossary.md](./glossary.md) for the primitive and edge semantics before
 inventing a new record kind or relation.
@@ -73,10 +74,11 @@ Critical semantics:
   unless you deliberately want the competing proposals closed.
 - Edges are forward-only in payloads (`derives_from`, `supersedes`,
   `invalidates`); back-edges are materialized automatically.
-- Cites: `WriteCitation` (body may be a URL; optional `blob` + `role`), then
-  `cites: ["<cit-id>"]` on any epistemic create. Flatbread `refs` link
-  records → Citation → optional Blob. Bounded digests omit Blob bodies —
-  use `effort get`.
+- External sources: create a `WriteCitation` record (its body may be a URL,
+  with optional `blob` and `role` fields), then add
+  `cites: ["<cit-id>"]` when creating an Issue, Finding, Decision,
+  Constraint, or Risk. A Citation may point to a Blob for attached content.
+  Bounded digests omit Blob bodies; use `effort get <blob-id>` to read one.
 - When superseding, open the new record's body with a short rollup of what
   changed and why — reads render ancestors only as one-line checkpoints.
 - For a hard-to-reverse, surprising decision made after a real trade-off, use
@@ -152,12 +154,12 @@ server-side.
    for the full body. Reserve opening `.flatbread-efforts/**/*.md` for rare
    cases (e.g. digest byte-cap miss on an oversized record), not normal
    zoom-in.
-3. **During work:** if the source artifact needs capture, teach Blob first with
-   `WriteBlob`; then create the source with `WriteCitation`; then do the
-   epistemic write using `cites: ["<cit-id>"]`. There is no cite retro-link
-   mutation, so create the Citation before the Finding/Decision/Constraint/Risk
-   that should cite it. Open Issues for real gaps/blockers, and record
-   Decisions with `derives_from` citing the Findings, Constraints, and Issues
+3. **During work:** when outside material supports a record, save large
+   content with `WriteBlob` if needed, then create a `WriteCitation`, then
+   create the Issue, Finding, Decision, Constraint, or Risk with
+   `cites: ["<cit-id>"]`. You cannot add a citation later, so create the
+   Citation first. Open Issues for real gaps or blockers, and use
+   `derives_from` on Decisions to link the Findings, Constraints, and Issues
    they respond to.
 4. **On commitment:** `AcceptDecision` (mind `rejectSiblings`), `ResolveIssue`
    with `resolvedBy` citing the closing Decision/Findings.

--- a/packages/effort-graph/skills/effort-graph/SKILL.md
+++ b/packages/effort-graph/skills/effort-graph/SKILL.md
@@ -77,8 +77,10 @@ Critical semantics:
 - External sources: create a `WriteCitation` record (its body may be a URL,
   with optional `blob` and `role` fields), then add
   `cites: ["<cit-id>"]` when creating an Issue, Finding, Decision,
-  Constraint, or Risk. A Citation may point to a Blob for attached content.
-  Bounded digests omit Blob bodies; use `effort get <blob-id>` to read one.
+  Constraint, or Risk. Both the Citation in `cites` and the Blob in
+  `Citation.blob` must belong to the same Effort as the record that links to
+  them. Bounded digests omit Blob bodies; use `effort get <blob-id>` to read
+  one.
 - When superseding, open the new record's body with a short rollup of what
   changed and why — reads render ancestors only as one-line checkpoints.
 - For a hard-to-reverse, surprising decision made after a real trade-off, use

--- a/packages/effort-graph/skills/effort-graph/SKILL.md
+++ b/packages/effort-graph/skills/effort-graph/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: effort-graph
-description: Journal reasoning (decisions, findings, issues, constraints, risks) into a Flatbread Effort Graph and recall it with bounded reads. Use when starting or resuming a thread of work, recording a decision or finding, resolving an issue, checking what is blocking or still open on an effort, or when the user mentions effort graph, journaling, blocking decisions, or agent memory.
+description: Journal reasoning (decisions, findings, issues, constraints, risks, citations, blobs) into a Flatbread Effort Graph and recall it with bounded reads. Use when starting or resuming a thread of work, recording a decision or finding, resolving an issue, checking what is blocking or still open on an effort, or when the user mentions effort graph, journaling, blocking decisions, agent memory, citation, blob, cites, longform, WriteCitation, or WriteBlob.
 ---
 
 # Effort Graph — agent journaling and recall
 
 The Effort Graph is persistent, queryable memory for long-horizon work, stored
-as markdown records in the repo. Six primitives: **Effort** (the anchor thread
-of work), **Issue**, **Finding**, **Decision**, **Constraint**, **Risk**.
-Every record belongs to exactly one Effort. You write through 13 typed
-mutations and read through 5 bounded queries — never by hand-editing record
-frontmatter (bodies may be edited freely).
+as markdown records in the repo. Eight collections/primitives: epistemic
+**Effort**, **Issue**, **Finding**, **Decision**, **Constraint**, and
+**Risk**, plus non-epistemic **Citation** and **Blob**. Every record belongs
+to exactly one Effort. You write through 15 typed mutations and read through
+5 bounded queries — never by hand-editing record frontmatter (bodies may be
+edited freely).
 
 Read [glossary.md](./glossary.md) for the primitive and edge semantics before
 inventing a new record kind or relation.
@@ -43,7 +44,7 @@ export default defineConfig({
 });
 ```
 
-Records live under `<root>/{efforts,issues,findings,decisions,constraints,risks}/`.
+Records live under `<root>/{efforts,issues,findings,decisions,constraints,risks,citations,blobs}/`.
 The write journal is `<root>/.journal/`; read digests cache under
 `.flatbread/effort-graph/read-cache/` (both gitignored).
 
@@ -151,9 +152,13 @@ server-side.
    for the full body. Reserve opening `.flatbread-efforts/**/*.md` for rare
    cases (e.g. digest byte-cap miss on an oversized record), not normal
    zoom-in.
-3. **During work:** journal Findings as evidence lands; open Issues for real
-   gaps/blockers; record Decisions with `derives_from` citing the Findings,
-   Constraints, and Issues they respond to.
+3. **During work:** if the source artifact needs capture, teach Blob first with
+   `WriteBlob`; then create the source with `WriteCitation`; then do the
+   epistemic write using `cites: ["<cit-id>"]`. There is no cite retro-link
+   mutation, so create the Citation before the Finding/Decision/Constraint/Risk
+   that should cite it. Open Issues for real gaps/blockers, and record
+   Decisions with `derives_from` citing the Findings, Constraints, and Issues
+   they respond to.
 4. **On commitment:** `AcceptDecision` (mind `rejectSiblings`), `ResolveIssue`
    with `resolvedBy` citing the closing Decision/Findings.
 5. Maintenance: `flatbread effort cache prune` deletes digests older than

--- a/packages/effort-graph/skills/effort-graph/glossary.md
+++ b/packages/effort-graph/skills/effort-graph/glossary.md
@@ -74,9 +74,8 @@ writer-materialized reverse projections.
 
 `cites` links an Issue, Finding, Decision, Constraint, or Risk to a Citation.
 It accepts Citation ids only, never Blob ids. A Citation may optionally point
-to a Blob. `flatbread effort relations` follows `cites` links, but does not
-follow Blob attachments; use `flatbread effort get <blob-id>` to read an
-attachment.
+to a Blob. Both links must stay within the same Effort. `flatbread effort relations` follows `cites` links, but does not follow Blob attachments; use
+`flatbread effort get <blob-id>` to read an attachment.
 
 New edge vocabulary needs a dogfooded query the existing vocabulary cannot
 express.

--- a/packages/effort-graph/skills/effort-graph/glossary.md
+++ b/packages/effort-graph/skills/effort-graph/glossary.md
@@ -50,21 +50,20 @@ accepted.
 
 ### Citation
 
-A first-class cite target that explains what evidence is and how it relates.
-Epistemic records point at Citations via the homogeneous `cites` ref so
-Flatbread validates and GraphQL-resolves the edge. A Citation body alone is
-valid — often a URL string. An optional `blob` ref attaches a longform/opaque
-payload when needed. Optional `role` labels the relationship (e.g. evidence,
-context). Citations have no proposed/accepted lifecycle.
+A record for an external source or reference. Issues, Findings, Decisions,
+Constraints, and Risks link to Citations through `cites`. A Citation body can
+be only a URL. Its optional `blob` field attaches stored content when needed,
+and its optional `role` describes the relationship (for example, `evidence`
+or `context`). Citations do not have a proposed/accepted lifecycle.
 
 ### Blob
 
-A citeable, non-epistemic payload: opaque content of any format (markdown,
-JSON, images, etc.) with no proposed/accepted lifecycle. Blobs are ordinary
-Flatbread content (filesystem-first; other sources such as S3/CDN may back
-them later). Records do not cite Blobs directly — they cite a Citation that
-may optionally ref a Blob. Bounded digests omit Blob bodies by default; use
-`effort get <blob-id>` to read the payload.
+Stored content of any format (markdown, JSON, images, and more). Blobs do not
+have a proposed/accepted lifecycle. They are ordinary Flatbread content:
+filesystem-backed today, with other sources such as S3 or a CDN possible
+later. Records do not cite Blobs directly. Instead, they cite a Citation,
+which may optionally point to a Blob. Bounded digests omit Blob bodies by
+default; use `effort get <blob-id>` to read the content.
 
 ## Edges
 
@@ -73,10 +72,11 @@ record of the same primitive, while `invalidates` says a record was wrong.
 Those forward edges are authoritative; `superseded_by` and `invalidated_by` are
 writer-materialized reverse projections.
 
-`cites` is a homogeneous Flatbread `refs` edge to Citation on every epistemic
-record (Effort, Issue, Finding, Decision, Constraint, Risk). Citation may
-optionally `blob` → Blob. Bounded `effort relations` walks `cites` but not
-`blob`; zoom with `effort get`.
+`cites` links an Issue, Finding, Decision, Constraint, or Risk to a Citation.
+It accepts Citation ids only, never Blob ids. A Citation may optionally point
+to a Blob. `flatbread effort relations` follows `cites` links, but does not
+follow Blob attachments; use `flatbread effort get <blob-id>` to read an
+attachment.
 
 New edge vocabulary needs a dogfooded query the existing vocabulary cannot
 express.

--- a/packages/effort-graph/skills/effort-graph/glossary.md
+++ b/packages/effort-graph/skills/effort-graph/glossary.md
@@ -75,7 +75,8 @@ writer-materialized reverse projections.
 
 `cites` is a homogeneous Flatbread `refs` edge to Citation on every epistemic
 record (Effort, Issue, Finding, Decision, Constraint, Risk). Citation may
-optionally `blob` → Blob.
+optionally `blob` → Blob. Bounded `effort relations` walks `cites` but not
+`blob`; zoom with `effort get`.
 
 New edge vocabulary needs a dogfooded query the existing vocabulary cannot
 express.

--- a/packages/effort-graph/skills/effort-graph/reference.md
+++ b/packages/effort-graph/skills/effort-graph/reference.md
@@ -19,14 +19,15 @@ on all creates except `CreateEffort`, `WriteCitation`, and `WriteBlob`:
 `derives_from[]`, `supersedes[]`, `invalidates[]` (arrays of existing ids;
 targets are validated).
 
-Optional `cites[]` on all epistemic creates (`CreateEffort` and every `Write*`
-except `WriteCitation` / `WriteBlob`): existing **Citation** ids (homogeneous
-Flatbread `refs` → Citation).
+Optional `cites[]` on epistemic creates (every `Write*` except `WriteCitation`
+/ `WriteBlob`): existing **Citation** ids in the **same effort** (homogeneous
+Flatbread `refs` → Citation). Create Citations first, then cite them from
+Findings, Decisions, Issues, etc. — `CreateEffort` does not take `cites`.
 
 ### Effort lifecycle
 
 ```json
-{"type":"CreateEffort","title":"...","body":"...","slug":"optional","cites":["<cit-id>"]}
+{"type":"CreateEffort","title":"...","body":"...","slug":"optional"}
 {"type":"SetEffortStatus","effortId":"<eff-id>","status":"active|paused|completed|abandoned"}
 ```
 
@@ -131,7 +132,8 @@ flatbread effort cache prune
 ```
 
 - `--kinds`: `effort|issue|finding|decision|constraint|risk|citation|blob`
-  (records: default all non-effort kinds, including `citation` and `blob`).
+  (records: default all non-effort kinds including `citation`; `blob` is
+  opt-in via `--kinds`).
 - `list --status`: defaults to `active`; valid values are exactly `active`,
   `paused`, `completed`, and `abandoned`. Values are ORed and results are
   ordered by `created_at` ascending, then `id`.

--- a/packages/effort-graph/skills/effort-graph/reference.md
+++ b/packages/effort-graph/skills/effort-graph/reference.md
@@ -47,7 +47,8 @@ Initial states: Issue `status: open`; Decision `state: proposed`; Risk
 `state: open`. Citation and Blob have no lifecycle state.
 
 A Citation body alone is valid (commonly a URL). `blob` is optional; use it
-only when you need to attach stored content such as a document or JSON.
+only when you need to attach stored content such as a document or JSON. When
+provided, `blob` must be the id of a Blob in the same Effort as the Citation.
 
 ### Add links between existing records
 

--- a/packages/effort-graph/skills/effort-graph/reference.md
+++ b/packages/effort-graph/skills/effort-graph/reference.md
@@ -19,10 +19,10 @@ on all creates except `CreateEffort`, `WriteCitation`, and `WriteBlob`:
 `derives_from[]`, `supersedes[]`, `invalidates[]` (arrays of existing ids;
 targets are validated).
 
-Optional `cites[]` on epistemic creates (every `Write*` except `WriteCitation`
-/ `WriteBlob`): existing **Citation** ids in the **same effort** (homogeneous
-Flatbread `refs` → Citation). Create Citations first, then cite them from
-Findings, Decisions, Issues, etc. — `CreateEffort` does not take `cites`.
+Optional `cites[]` on Issue, Finding, Decision, Constraint, and Risk creates:
+existing **Citation** ids in the **same Effort**. Create Citations first, then
+add their ids when creating Findings, Decisions, Issues, and other records.
+`CreateEffort` does not accept `cites`.
 
 ### Effort lifecycle
 
@@ -46,10 +46,10 @@ Findings, Decisions, Issues, etc. — `CreateEffort` does not take `cites`.
 Initial states: Issue `status: open`; Decision `state: proposed`; Risk
 `state: open`. Citation and Blob have no lifecycle state.
 
-A Citation body alone is valid (commonly a URL). `blob` is optional — attach
-a Blob only when you need a longform/opaque payload behind the cite.
+A Citation body alone is valid (commonly a URL). `blob` is optional; use it
+only when you need to attach stored content such as a document or JSON.
 
-### Edge retro-linking (records must already exist)
+### Add links between existing records
 
 ```json
 {"type":"Supersede","supersederId":"<id>","targetId":"<same-kind-id>"}
@@ -131,9 +131,9 @@ flatbread effort blocking-decisions <effortId> [consistency flags]
 flatbread effort cache prune
 ```
 
-- `--kinds`: `effort|issue|finding|decision|constraint|risk|citation|blob`
-  (records: default all non-effort kinds including `citation`; `blob` is
-  opt-in via `--kinds`).
+- `--kinds`: `effort|issue|finding|decision|constraint|risk|citation|blob`.
+  `records` includes every non-Effort kind except Blob by default. Add
+  `--kinds blob` when you need Blob records.
 - `list --status`: defaults to `active`; valid values are exactly `active`,
   `paused`, `completed`, and `abandoned`. Values are ORed and results are
   ordered by `created_at` ascending, then `id`.

--- a/packages/effort-graph/skills/effort-modeling/DECISION-BODY.md
+++ b/packages/effort-graph/skills/effort-modeling/DECISION-BODY.md
@@ -25,10 +25,11 @@ What becomes easier, harder, required, or intentionally deferred?
 What evidence would justify revisiting this?
 ```
 
-The body belongs to the Decision record. Wire epistemic upstream through
-`derives_from` when creating it — the Findings, Constraints, Risks, and Issues
-this Decision responds to or weighs.
+The body belongs to the Decision record. When creating it, use
+`derives_from` to link the Findings, Constraints, Risks, and Issues the
+Decision responds to or weighs.
 
-For external evidence (URLs, docs, longform captures), do not paste the source
-into the body. Use `WriteBlob` when the payload is longform, then
-`WriteCitation`, then pass `cites: ["<cit-id>"]` on the Decision create.
+For external evidence (URLs, documents, or saved content), do not paste the
+source into the body. If needed, save the content with `WriteBlob`, then
+create a `WriteCitation`, then pass `cites: ["<cit-id>"]` when creating the
+Decision.

--- a/packages/effort-graph/skills/effort-modeling/DECISION-BODY.md
+++ b/packages/effort-graph/skills/effort-modeling/DECISION-BODY.md
@@ -25,5 +25,10 @@ What becomes easier, harder, required, or intentionally deferred?
 What evidence would justify revisiting this?
 ```
 
-The body belongs to the Decision record. Cite related Findings, Constraints,
-Risks, and Issues through `derives_from` when creating it.
+The body belongs to the Decision record. Wire epistemic upstream through
+`derives_from` when creating it — the Findings, Constraints, Risks, and Issues
+this Decision responds to or weighs.
+
+For external evidence (URLs, docs, longform captures), do not paste the source
+into the body. Use `WriteBlob` when the payload is longform, then
+`WriteCitation`, then pass `cites: ["<cit-id>"]` on the Decision create.

--- a/packages/effort-graph/skills/effort-modeling/SKILL.md
+++ b/packages/effort-graph/skills/effort-modeling/SKILL.md
@@ -44,32 +44,30 @@ Use `flatbread effort write` for the current Effort, following
 - **Risk** — a prospective negative outcome with likelihood and severity.
 - **Decision** — a proposed or accepted commitment among alternatives.
 
-### Three ways to "cite"
+### Two kinds of links
 
-Do not conflate these:
+Use these links for different purposes:
 
-- **Vernacular "cite"** — ordinary language for pointing at evidence.
-- **`cites`** — typed Flatbread `refs` edge from an epistemic record to a
-  **Citation** (external URL, doc, or longform capture). Records never cite
-  Blobs directly.
-- **`derives_from`** — causal upstream **epistemic** context: the Findings,
-  Constraints, Risks, and Issues this record responds to or weighs.
+- **`cites`** — links a record to a **Citation** for an external URL,
+  document, or saved source. Records never cite Blobs directly.
+- **`derives_from`** — links a record to the Findings, Constraints, Risks,
+  and Issues that informed it.
 
-A Decision typically `derives_from` the epistemic records it synthesizes and
-`cites` Citations for outside sources.
+A Decision typically uses `derives_from` for project reasoning and `cites` for
+outside sources.
 
 ### External evidence (URL or longform)
 
-When a Finding, Decision, Constraint, or Risk rests on external evidence, journal
-it as a Citation — do not duplicate the source in the epistemic body:
+When a Finding, Decision, Constraint, or Risk rests on an external source,
+create a Citation instead of copying the source into the record body:
 
-1. **`WriteBlob`** — only when the source is longform or opaque content that
-   needs capture (markdown, JSON, image, etc.).
+1. **`WriteBlob`** — only when you need to save large or non-text content
+   (markdown, JSON, an image, and so on).
 2. **`WriteCitation`** — body is often the URL string; pass optional `blob` and
    `role` when needed.
-3. **Epistemic write** — pass `cites: ["<cit-id>"]` on the create. There is no
-   cite retro-link mutation, so create the Citation before the record that
-   should cite it.
+3. **Create the record** — pass `cites: ["<cit-id>"]` when creating the
+   Finding, Decision, Constraint, or Risk. You cannot add a citation later,
+   so create the Citation first.
 
 Record a Decision when it is hard to reverse, surprising without context, and
 the result of a real trade-off. Create it as proposed while the user is still

--- a/packages/effort-graph/skills/effort-modeling/SKILL.md
+++ b/packages/effort-graph/skills/effort-modeling/SKILL.md
@@ -44,6 +44,33 @@ Use `flatbread effort write` for the current Effort, following
 - **Risk** — a prospective negative outcome with likelihood and severity.
 - **Decision** — a proposed or accepted commitment among alternatives.
 
+### Three ways to "cite"
+
+Do not conflate these:
+
+- **Vernacular "cite"** — ordinary language for pointing at evidence.
+- **`cites`** — typed Flatbread `refs` edge from an epistemic record to a
+  **Citation** (external URL, doc, or longform capture). Records never cite
+  Blobs directly.
+- **`derives_from`** — causal upstream **epistemic** context: the Findings,
+  Constraints, Risks, and Issues this record responds to or weighs.
+
+A Decision typically `derives_from` the epistemic records it synthesizes and
+`cites` Citations for outside sources.
+
+### External evidence (URL or longform)
+
+When a Finding, Decision, Constraint, or Risk rests on external evidence, journal
+it as a Citation — do not duplicate the source in the epistemic body:
+
+1. **`WriteBlob`** — only when the source is longform or opaque content that
+   needs capture (markdown, JSON, image, etc.).
+2. **`WriteCitation`** — body is often the URL string; pass optional `blob` and
+   `role` when needed.
+3. **Epistemic write** — pass `cites: ["<cit-id>"]` on the create. There is no
+   cite retro-link mutation, so create the Citation before the record that
+   should cite it.
+
 Record a Decision when it is hard to reverse, surprising without context, and
 the result of a real trade-off. Create it as proposed while the user is still
 deciding; call `AcceptDecision` only after they commit. Always pass

--- a/packages/effort-graph/skills/grill-with-efforts/SKILL.md
+++ b/packages/effort-graph/skills/grill-with-efforts/SKILL.md
@@ -14,9 +14,9 @@ and resolve dependent choices in order. Explore the codebase for facts, but
 leave choices to the user. Do not implement the plan until shared understanding
 is confirmed.
 
-When external evidence informs a choice, journal it through the Citation
-workflow (`WriteBlob` if longform → `WriteCitation` → epistemic write with
-`cites`) rather than pasting URLs or longform into epistemic bodies. Use
-`derives_from` for in-graph epistemic upstream; typed `cites` are for
-Citation records only — see effort-modeling for vernacular cite vs `cites` vs
-`derives_from`.
+When an external source informs a choice, create a `WriteCitation` record
+instead of pasting the source into another record. Save large content first
+with `WriteBlob` when needed, then create the Citation, then create the
+Finding or Decision with `cites`. Use `derives_from` to link Findings, Issues,
+Constraints, and Risks within the project; use `cites` only for Citation
+records. See effort-modeling for details.

--- a/packages/effort-graph/skills/grill-with-efforts/SKILL.md
+++ b/packages/effort-graph/skills/grill-with-efforts/SKILL.md
@@ -13,3 +13,10 @@ Offer a recommended answer for each decision, wait for the user's response,
 and resolve dependent choices in order. Explore the codebase for facts, but
 leave choices to the user. Do not implement the plan until shared understanding
 is confirmed.
+
+When external evidence informs a choice, journal it through the Citation
+workflow (`WriteBlob` if longform → `WriteCitation` → epistemic write with
+`cites`) rather than pasting URLs or longform into epistemic bodies. Use
+`derives_from` for in-graph epistemic upstream; typed `cites` are for
+Citation records only — see effort-modeling for vernacular cite vs `cites` vs
+`derives_from`.

--- a/packages/effort-graph/src/__tests__/planner.test.ts
+++ b/packages/effort-graph/src/__tests__/planner.test.ts
@@ -79,6 +79,18 @@ test('8 CreateEffort', (t) => {
   });
   t.is(w[0].beforeBytes, undefined);
 });
+test('CreateEffort rejects cites before planning a write', (t) => {
+  const input = {
+    type: 'CreateEffort',
+    title: 'New',
+    body: '',
+    cites: ['cit-paper--0123456789abcdef'],
+  } as unknown as import('../schemas.js').EffortGraphMutation;
+  t.throws(() => planMutation(input, snap(), '/root', now), {
+    message:
+      'CreateEffort does not accept cites; create the Effort before its Citations.',
+  });
+});
 test('9 SetEffortStatus', (t) => {
   const s = snap();
   const w = planMutation(

--- a/packages/effort-graph/src/__tests__/planner.test.ts
+++ b/packages/effort-graph/src/__tests__/planner.test.ts
@@ -572,3 +572,141 @@ test('25 cites must target Citation', (t) => {
     { message: /cites must target a Citation/ }
   );
 });
+test('26 cites must belong to same effort', (t) => {
+  const otherEffort = 'eff-two--0123456789abcdef';
+  const citId = 'cit-paper--0123456789abcdef';
+  const citation = record(
+    citId,
+    'citation',
+    {
+      id: citId,
+      effort: otherEffort,
+      title: 'Paper',
+      created_at: '2025-01-01T00:00:00.000Z',
+    },
+    'https://example.com/paper'
+  );
+  const otherEffortRecord = record(otherEffort, 'effort', {
+    id: otherEffort,
+    title: 'Other',
+    created_at: '2025-01-01T00:00:00.000Z',
+    status: 'active',
+  });
+  t.throws(
+    () =>
+      planMutation(
+        {
+          type: 'WriteFinding',
+          id: ids.finding,
+          effort: E,
+          title: 'F',
+          body: '',
+          kind: 'measurement',
+          cites: [citId],
+        },
+        snap([otherEffortRecord, citation]),
+        '/root',
+        now
+      ),
+    { message: /Different effort/ }
+  );
+});
+test('27 Citation.blob must belong to same effort', (t) => {
+  const otherEffort = 'eff-two--0123456789abcdef';
+  const blobId = 'blb-payload--0123456789abcdef';
+  const blob = record(blobId, 'blob', {
+    id: blobId,
+    effort: otherEffort,
+    title: 'Payload',
+    created_at: '2025-01-01T00:00:00.000Z',
+  });
+  const otherEffortRecord = record(otherEffort, 'effort', {
+    id: otherEffort,
+    title: 'Other',
+    created_at: '2025-01-01T00:00:00.000Z',
+    status: 'active',
+  });
+  t.throws(
+    () =>
+      planMutation(
+        {
+          type: 'WriteCitation',
+          id: 'cit-dump--0123456789abcdef',
+          effort: E,
+          title: 'Dump cite',
+          body: 'Local research dump',
+          blob: blobId,
+        },
+        snap([otherEffortRecord, blob]),
+        '/root',
+        now
+      ),
+    { message: /Different effort/ }
+  );
+});
+test('28 Citation.blob must target Blob', (t) => {
+  const finding = record(ids.finding, 'finding', {
+    id: ids.finding,
+    effort: E,
+    title: 'F',
+    created_at: '2025-01-01T00:00:00.000Z',
+    kind: 'x',
+  });
+  t.throws(
+    () =>
+      planMutation(
+        {
+          type: 'WriteCitation',
+          id: 'cit-bad--0123456789abcdef',
+          effort: E,
+          title: 'Bad cite',
+          body: 'note',
+          blob: ids.finding,
+        },
+        snap([finding]),
+        '/root',
+        now
+      ),
+    { message: /Citation\.blob must target a Blob/ }
+  );
+});
+test('29 same-effort cites and blob happy path', (t) => {
+  const blobId = 'blb-payload--0123456789abcdef';
+  const citId = 'cit-paper--0123456789abcdef';
+  const blob = record(blobId, 'blob', {
+    id: blobId,
+    effort: E,
+    title: 'Payload',
+    created_at: '2025-01-01T00:00:00.000Z',
+    kind: 'markdown',
+  });
+  const citation = record(
+    citId,
+    'citation',
+    {
+      id: citId,
+      effort: E,
+      title: 'Paper',
+      created_at: '2025-01-01T00:00:00.000Z',
+      blob: blobId,
+      role: 'evidence',
+    },
+    'https://example.com/paper'
+  );
+  const w = planMutation(
+    {
+      type: 'WriteDecision',
+      id: ids.decision,
+      effort: E,
+      title: 'D',
+      body: 'rationale',
+      cites: [citId],
+    },
+    snap([blob, citation]),
+    '/root',
+    now
+  );
+  t.deepEqual(parseDocument(w[0].afterBytes, 'decision').frontmatter.cites, [
+    citId,
+  ]);
+});

--- a/packages/effort-graph/src/__tests__/planner.test.ts
+++ b/packages/effort-graph/src/__tests__/planner.test.ts
@@ -608,7 +608,11 @@ test('26 cites must belong to same effort', (t) => {
         '/root',
         now
       ),
-    { message: /Different effort/ }
+    {
+      message: new RegExp(
+        `cites target ${citId} belongs to a different effort`
+      ),
+    }
   );
 });
 test('27 Citation.blob must belong to same effort', (t) => {
@@ -641,7 +645,11 @@ test('27 Citation.blob must belong to same effort', (t) => {
         '/root',
         now
       ),
-    { message: /Different effort/ }
+    {
+      message: new RegExp(
+        `Citation\\.blob ${blobId} belongs to a different effort`
+      ),
+    }
   );
 });
 test('28 Citation.blob must target Blob', (t) => {

--- a/packages/effort-graph/src/__tests__/preset.test.ts
+++ b/packages/effort-graph/src/__tests__/preset.test.ts
@@ -7,7 +7,6 @@ test('returns exactly eight entries with exact paths and refs', (t) => {
     {
       collection: 'Effort',
       path: '.flatbread-efforts/efforts',
-      refs: { cites: 'Citation' },
     },
     {
       collection: 'Issue',
@@ -110,9 +109,13 @@ test('polymorphic union fields are absent from every refs map', (t) => {
   }
 });
 
-test('cites is homogeneous Citation ref on every epistemic collection', (t) => {
+test('cites is a Citation ref on records that can create cites', (t) => {
   for (const entry of effortGraphContent()) {
-    if (entry.collection === 'Blob' || entry.collection === 'Citation') {
+    if (
+      entry.collection === 'Effort' ||
+      entry.collection === 'Blob' ||
+      entry.collection === 'Citation'
+    ) {
       t.falsy(entry.refs?.cites);
       continue;
     }

--- a/packages/effort-graph/src/__tests__/schemas.test.ts
+++ b/packages/effort-graph/src/__tests__/schemas.test.ts
@@ -176,6 +176,15 @@ test('WriteCitation allows URL body without blob; cites accept Citation ids', (t
   );
 });
 
+test('CreateEffort rejects cites', (t) => {
+  t.throws(() =>
+    EffortGraphMutationSchema.parse({
+      ...validMutations.CreateEffort,
+      cites: [`cit-paper--${suffix}`],
+    })
+  );
+});
+
 test('frontmatter schemas passthrough unknown keys', (t) => {
   const parsed = EffortFrontmatterSchema.parse({
     id: eff,

--- a/packages/effort-graph/src/__tests__/schemas.test.ts
+++ b/packages/effort-graph/src/__tests__/schemas.test.ts
@@ -177,12 +177,20 @@ test('WriteCitation allows URL body without blob; cites accept Citation ids', (t
 });
 
 test('CreateEffort rejects cites', (t) => {
-  t.throws(() =>
-    EffortGraphMutationSchema.parse({
-      ...validMutations.CreateEffort,
-      cites: [`cit-paper--${suffix}`],
-    })
-  );
+  const result = EffortGraphMutationSchema.safeParse({
+    ...validMutations.CreateEffort,
+    cites: [`cit-paper--${suffix}`],
+  });
+  t.false(result.success);
+  if (!result.success)
+    t.true(
+      result.error.issues.some(
+        (issue) =>
+          issue.code === 'unrecognized_keys' &&
+          issue.keys.includes('cites') &&
+          issue.path.length === 0
+      )
+    );
 });
 
 test('frontmatter schemas passthrough unknown keys', (t) => {

--- a/packages/effort-graph/src/__tests__/writer.test.ts
+++ b/packages/effort-graph/src/__tests__/writer.test.ts
@@ -394,7 +394,45 @@ test('WriteFinding rejects cites from another effort', async (t) => {
       kind: 'measurement',
       cites: [foreignCitation],
     }),
-    { instanceOf: EffortGraphValidationError, message: /Different effort/ }
+    {
+      instanceOf: EffortGraphValidationError,
+      message: new RegExp(
+        `cites target ${foreignCitation} belongs to a different effort`
+      ),
+    }
+  );
+});
+
+test('WriteCitation rejects a Blob from another effort', async (t) => {
+  const { writer } = await makeWriter();
+  const effort = soleId(
+    await writer.mutate({ type: 'CreateEffort', title: 'E1', body: '' })
+  );
+  const otherEffort = soleId(
+    await writer.mutate({ type: 'CreateEffort', title: 'E2', body: '' })
+  );
+  const foreignBlob = soleId(
+    await writer.mutate({
+      type: 'WriteBlob',
+      effort: otherEffort,
+      title: 'Foreign payload',
+      body: '',
+    })
+  );
+  await t.throwsAsync(
+    writer.mutate({
+      type: 'WriteCitation',
+      effort,
+      title: 'Source',
+      body: 'https://example.com/source',
+      blob: foreignBlob,
+    }),
+    {
+      instanceOf: EffortGraphValidationError,
+      message: new RegExp(
+        `Citation\\.blob ${foreignBlob} belongs to a different effort`
+      ),
+    }
   );
 });
 

--- a/packages/effort-graph/src/__tests__/writer.test.ts
+++ b/packages/effort-graph/src/__tests__/writer.test.ts
@@ -6,6 +6,7 @@ import matter from 'gray-matter';
 import { createEffortGraphWriter } from '../writer.js';
 import { EffortGraphValidationError } from '../errors.js';
 import type { EffortGraphWriter, MutationResult } from '../types.js';
+import type { EffortGraphMutation } from '../schemas.js';
 
 async function makeWriter(): Promise<{
   root: string;
@@ -23,6 +24,23 @@ async function readFrontmatter(root: string, relativePath: string) {
 function soleId(result: MutationResult): string {
   return result.artifacts[0].id;
 }
+
+test('CreateEffort rejects cites through the writer', async (t) => {
+  const { writer } = await makeWriter();
+  await t.throwsAsync(
+    writer.mutate({
+      type: 'CreateEffort',
+      title: 'E',
+      body: '',
+      cites: ['cit-paper--0123456789abcdef'],
+    } as unknown as EffortGraphMutation),
+    {
+      instanceOf: EffortGraphValidationError,
+      message:
+        'CreateEffort does not accept cites; create the Effort before its Citations.',
+    }
+  );
+});
 
 test('WriteDecision with supersedes materializes superseded_by on the target file', async (t) => {
   const { root, writer } = await makeWriter();

--- a/packages/effort-graph/src/__tests__/writer.test.ts
+++ b/packages/effort-graph/src/__tests__/writer.test.ts
@@ -326,6 +326,78 @@ test('SetRiskState realized requires at least one Finding in evidence', async (t
   t.deepEqual(result.artifacts[0].frontmatter.evidence, [finding]);
 });
 
+test('WriteBlob, WriteCitation(blob), and WriteFinding(cites) persist same-effort links', async (t) => {
+  const { root, writer } = await makeWriter();
+  const effort = soleId(
+    await writer.mutate({ type: 'CreateEffort', title: 'E', body: '' })
+  );
+  const blobId = soleId(
+    await writer.mutate({
+      type: 'WriteBlob',
+      effort,
+      title: 'Payload',
+      body: '# longform research\n',
+      kind: 'markdown',
+    })
+  );
+  const blobDoc = await readFrontmatter(root, `blobs/${blobId}.md`);
+  t.is(blobDoc.data.effort, effort);
+  t.is(blobDoc.content.trim(), '# longform research');
+  const citationId = soleId(
+    await writer.mutate({
+      type: 'WriteCitation',
+      effort,
+      title: 'Paper',
+      body: 'https://example.com/paper',
+      role: 'evidence',
+      blob: blobId,
+    })
+  );
+  const citationDoc = await readFrontmatter(root, `citations/${citationId}.md`);
+  t.is(citationDoc.data.blob, blobId);
+  const findingId = soleId(
+    await writer.mutate({
+      type: 'WriteFinding',
+      effort,
+      title: 'F',
+      body: 'short',
+      kind: 'measurement',
+      cites: [citationId],
+    })
+  );
+  const findingDoc = await readFrontmatter(root, `findings/${findingId}.md`);
+  t.deepEqual(findingDoc.data.cites, [citationId]);
+});
+
+test('WriteFinding rejects cites from another effort', async (t) => {
+  const { writer } = await makeWriter();
+  const effort = soleId(
+    await writer.mutate({ type: 'CreateEffort', title: 'E1', body: '' })
+  );
+  const otherEffort = soleId(
+    await writer.mutate({ type: 'CreateEffort', title: 'E2', body: '' })
+  );
+  const foreignCitation = soleId(
+    await writer.mutate({
+      type: 'WriteCitation',
+      effort: otherEffort,
+      title: 'Foreign',
+      body: 'https://example.com/foreign',
+    })
+  );
+  await t.throwsAsync(
+    writer.mutate({
+      type: 'WriteFinding',
+      effort,
+      title: 'F',
+      body: '',
+      kind: 'measurement',
+      cites: [foreignCitation],
+    }),
+    { instanceOf: EffortGraphValidationError, message: /Different effort/ }
+  );
+});
+
 test('generation tokens increment across successive mutations', async (t) => {
   const { writer } = await makeWriter();
   const first = await writer.mutate({

--- a/packages/effort-graph/src/planner.ts
+++ b/packages/effort-graph/src/planner.ts
@@ -90,6 +90,10 @@ export function planMutation(
     });
   };
   if (input.type === 'CreateEffort') {
+    if ('cites' in input)
+      throw new EffortGraphValidationError(
+        'CreateEffort does not accept cites; create the Effort before its Citations.'
+      );
     const id =
       input.id ?? generateArtifactId('effort', input.title, randomBytes);
     if (!validateArtifactId(id, 'effort') || snapshot.hasId(id))

--- a/packages/effort-graph/src/planner.ts
+++ b/packages/effort-graph/src/planner.ts
@@ -36,6 +36,7 @@ function assertCites(
   get: (
     id: string
   ) => NonNullable<ReturnType<EffortGraphSnapshot['getRecord']>>,
+  effortId: string,
   cites: string[] | undefined
 ): void {
   for (const citeId of cites ?? []) {
@@ -44,6 +45,8 @@ function assertCites(
       throw new EffortGraphValidationError(
         `cites must target a Citation, got ${target.kind} (${citeId})`
       );
+    if (target.frontmatter.effort !== effortId)
+      throw new EffortGraphValidationError('Different effort');
   }
 }
 
@@ -98,7 +101,6 @@ export function planMutation(
       throw new EffortGraphValidationError(
         `Duplicate effort slug ${input.slug}`
       );
-    assertCites(get, input.cites);
     add(
       id,
       'effort',
@@ -114,7 +116,6 @@ export function planMutation(
         ...(input.created_by !== undefined
           ? { created_by: input.created_by }
           : {}),
-        ...(input.cites !== undefined ? { cites: input.cites } : {}),
       },
       input.body,
       'create'
@@ -146,9 +147,10 @@ export function planMutation(
         throw new EffortGraphValidationError(
           `Citation.blob must target a Blob, got ${blob.kind}`
         );
+      if (blob.frontmatter.effort !== raw.effort)
+        throw new EffortGraphValidationError('Different effort');
     }
-    if (EPISTEMIC_CREATE.has(kind) || kind === 'effort')
-      assertCites(get, raw.cites);
+    if (EPISTEMIC_CREATE.has(kind)) assertCites(get, raw.effort, raw.cites);
     const fm: Record<string, unknown> = {
       ...raw,
       id,

--- a/packages/effort-graph/src/planner.ts
+++ b/packages/effort-graph/src/planner.ts
@@ -46,7 +46,9 @@ function assertCites(
         `cites must target a Citation, got ${target.kind} (${citeId})`
       );
     if (target.frontmatter.effort !== effortId)
-      throw new EffortGraphValidationError('Different effort');
+      throw new EffortGraphValidationError(
+        `cites target ${citeId} belongs to a different effort`
+      );
   }
 }
 
@@ -148,7 +150,9 @@ export function planMutation(
           `Citation.blob must target a Blob, got ${blob.kind}`
         );
       if (blob.frontmatter.effort !== raw.effort)
-        throw new EffortGraphValidationError('Different effort');
+        throw new EffortGraphValidationError(
+          `Citation.blob ${raw.blob} belongs to a different effort`
+        );
     }
     if (EPISTEMIC_CREATE.has(kind)) assertCites(get, raw.effort, raw.cites);
     const fm: Record<string, unknown> = {

--- a/packages/effort-graph/src/preset.ts
+++ b/packages/effort-graph/src/preset.ts
@@ -12,7 +12,6 @@ export function effortGraphContent(
     {
       collection: 'Effort',
       path: `${root}/efforts`,
-      refs: { ...CITE_REFS },
     },
     {
       collection: 'Issue',

--- a/packages/effort-graph/src/schemas.ts
+++ b/packages/effort-graph/src/schemas.ts
@@ -20,12 +20,13 @@ const edges = {
   supersedes: id.array().optional(),
   invalidates: id.array().optional(),
 };
-export const CreateEffortSchema = z.object({
-  type: z.literal('CreateEffort'),
-  ...common,
-  ...cites,
-  slug: z.string().optional(),
-});
+export const CreateEffortSchema = z
+  .object({
+    type: z.literal('CreateEffort'),
+    ...common,
+    slug: z.string().optional(),
+  })
+  .strict();
 export const SetEffortStatusSchema = z.object({
   type: z.literal('SetEffortStatus'),
   effortId: id,

--- a/packages/flatbread/src/cli/effort.test.ts
+++ b/packages/flatbread/src/cli/effort.test.ts
@@ -15,12 +15,14 @@ import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { effortGraphContent } from '@flatbread/effort-graph';
 import { effortGraphContent as publicEffortGraphContent } from '../index.js';
+import { EffortGraphValidationError } from '@flatbread/effort-graph';
 import {
   handleEffortBlockingDecisions,
   handleEffortBootstrap,
   handleEffortGet,
   handleEffortList,
   handleEffortRecords,
+  handleEffortRelations,
   handleEffortWrite,
   inspectEffortBootstrap,
   mapEffortCliOptions,
@@ -435,6 +437,144 @@ export default { source: source(), transformer: transformer(), content: [{ colle
     const report = await inspectEffortBootstrap(cwd);
     t.is(report.requirements[0]?.code, 'EFFORT_BOOTSTRAP_PRESET_MISSING');
     t.is(await readFile(configPath, 'utf8'), config);
+  }
+);
+
+test.serial(
+  'effort handlers wire Blob, Citation cites, records browse, get, and relations',
+  async (t) => {
+    const cwd = await createTempProject('flatbread-effort-citation-blob-', t);
+    for (const directory of [
+      'efforts',
+      'issues',
+      'findings',
+      'decisions',
+      'constraints',
+      'risks',
+      'citations',
+      'blobs',
+    ])
+      await mkdir(join(cwd, '.flatbread-efforts', directory), {
+        recursive: true,
+      });
+    await writeFile(
+      join(cwd, 'flatbread.config.js'),
+      `import { source } from '@flatbread/source-filesystem';
+import { transformer } from '@flatbread/transformer-markdown';
+import { effortGraphContent } from '@flatbread/effort-graph';
+export default {
+  source: source(),
+  transformer: transformer(),
+  content: effortGraphContent('.flatbread-efforts'),
+};`
+    );
+    const effort = await handleEffortWrite(
+      JSON.stringify({ type: 'CreateEffort', title: 'Cite chain', body: '' }),
+      { cwd }
+    );
+    const effortId = effort.artifacts[0].id;
+    const otherEffort = await handleEffortWrite(
+      JSON.stringify({ type: 'CreateEffort', title: 'Other', body: '' }),
+      { cwd }
+    );
+    const blobBody = '# longform research payload\n\nDetailed content here.\n';
+    const blob = await handleEffortWrite(
+      JSON.stringify({
+        type: 'WriteBlob',
+        effort: effortId,
+        title: 'Payload',
+        body: blobBody,
+        kind: 'markdown',
+      }),
+      { cwd }
+    );
+    const blobId = blob.artifacts[0].id;
+    const citation = await handleEffortWrite(
+      JSON.stringify({
+        type: 'WriteCitation',
+        effort: effortId,
+        title: 'Paper',
+        body: 'https://example.com/paper',
+        role: 'evidence',
+        blob: blobId,
+      }),
+      { cwd }
+    );
+    const citationId = citation.artifacts[0].id;
+    const finding = await handleEffortWrite(
+      JSON.stringify({
+        type: 'WriteFinding',
+        effort: effortId,
+        title: 'Measured',
+        body: 'short',
+        kind: 'measurement',
+        cites: [citationId],
+      }),
+      { cwd }
+    );
+    const findingId = finding.artifacts[0].id;
+    const foreignCitation = await handleEffortWrite(
+      JSON.stringify({
+        type: 'WriteCitation',
+        effort: otherEffort.artifacts[0].id,
+        title: 'Foreign',
+        body: 'https://example.com/foreign',
+      }),
+      { cwd }
+    );
+    await t.throwsAsync(
+      () =>
+        handleEffortWrite(
+          JSON.stringify({
+            type: 'WriteFinding',
+            effort: effortId,
+            title: 'Bad cite',
+            body: '',
+            kind: 'measurement',
+            cites: [foreignCitation.artifacts[0].id],
+          }),
+          { cwd }
+        ),
+      { instanceOf: EffortGraphValidationError, message: /Different effort/ }
+    );
+
+    const browse = await handleEffortRecords(effortId, { cwd });
+    const browseDigest = await readFile(browse.artifact_path, 'utf8');
+    t.is(browse.page.returned, 2);
+    t.true(browseDigest.includes(citationId));
+    t.true(browseDigest.includes(findingId));
+    t.false(browseDigest.includes(`### ${blobId}`));
+    t.false(browseDigest.includes('longform research payload'));
+
+    const explicitBlob = await handleEffortRecords(effortId, {
+      cwd,
+      kinds: ['blob'],
+    });
+    const blobBrowseDigest = await readFile(explicitBlob.artifact_path, 'utf8');
+    t.true(blobBrowseDigest.includes(blobId));
+    t.true(blobBrowseDigest.includes('Blob body omitted from bounded digests'));
+    t.false(blobBrowseDigest.includes('Detailed content here.'));
+
+    const blobGet = await handleEffortGet(blobId, { cwd });
+    const blobGetDigest = await readFile(blobGet.artifact_path, 'utf8');
+    t.true(blobGetDigest.includes('longform research payload'));
+    t.true(blobGetDigest.includes('Detailed content here.'));
+    t.false(blobGetDigest.includes('Blob body omitted from bounded digests'));
+
+    const citesRelations = await handleEffortRelations(effortId, findingId, {
+      cwd,
+      relations: ['cites'],
+    });
+    const citesDigest = await readFile(citesRelations.artifact_path, 'utf8');
+    t.is(citesRelations.page.returned, 1);
+    t.true(citesDigest.includes(`### ${citationId}`));
+    t.false(citesDigest.includes(`### ${blobId}`));
+
+    const effortRelations = await handleEffortRelations(effortId, effortId, {
+      cwd,
+      relations: ['cites'],
+    });
+    t.is(effortRelations.page.returned, 0);
   }
 );
 

--- a/packages/flatbread/src/cli/effort.test.ts
+++ b/packages/flatbread/src/cli/effort.test.ts
@@ -473,6 +473,22 @@ export default {
       { cwd }
     );
     const effortId = effort.artifacts[0].id;
+    await t.throwsAsync(
+      () =>
+        handleEffortWrite(
+          JSON.stringify({
+            type: 'CreateEffort',
+            title: 'Invalid',
+            body: '',
+            cites: ['cit-paper--0123456789abcdef'],
+          }),
+          { cwd }
+        ),
+      {
+        instanceOf: EffortGraphValidationError,
+        message: /CreateEffort does not accept cites/,
+      }
+    );
     const otherEffort = await handleEffortWrite(
       JSON.stringify({ type: 'CreateEffort', title: 'Other', body: '' }),
       { cwd }
@@ -489,6 +505,34 @@ export default {
       { cwd }
     );
     const blobId = blob.artifacts[0].id;
+    const foreignBlob = await handleEffortWrite(
+      JSON.stringify({
+        type: 'WriteBlob',
+        effort: otherEffort.artifacts[0].id,
+        title: 'Foreign payload',
+        body: '',
+      }),
+      { cwd }
+    );
+    await t.throwsAsync(
+      () =>
+        handleEffortWrite(
+          JSON.stringify({
+            type: 'WriteCitation',
+            effort: effortId,
+            title: 'Invalid source',
+            body: 'https://example.com/invalid',
+            blob: foreignBlob.artifacts[0].id,
+          }),
+          { cwd }
+        ),
+      {
+        instanceOf: EffortGraphValidationError,
+        message: new RegExp(
+          `Citation\\.blob ${foreignBlob.artifacts[0].id} belongs to a different effort`
+        ),
+      }
+    );
     const citation = await handleEffortWrite(
       JSON.stringify({
         type: 'WriteCitation',
@@ -535,7 +579,12 @@ export default {
           }),
           { cwd }
         ),
-      { instanceOf: EffortGraphValidationError, message: /Different effort/ }
+      {
+        instanceOf: EffortGraphValidationError,
+        message: new RegExp(
+          `cites target ${foreignCitation.artifacts[0].id} belongs to a different effort`
+        ),
+      }
     );
 
     const browse = await handleEffortRecords(effortId, { cwd });

--- a/packages/flatbread/src/cli/effort.ts
+++ b/packages/flatbread/src/cli/effort.ts
@@ -5,6 +5,7 @@ import {
   pruneReadCache,
   createEffortGraphWriter,
   EffortGraphMutationSchema,
+  EffortGraphValidationError,
   EffortGraphReadValidationError,
   parseGenerationToken,
   findEffortGraphContentRoot,
@@ -116,7 +117,17 @@ export async function handleEffortWrite(
   artifacts: { id: string; path: string; operation: string }[];
   touched: { id: string; path: string }[];
 }> {
-  const input = EffortGraphMutationSchema.parse(JSON.parse(json));
+  const raw: unknown = JSON.parse(json);
+  if (
+    raw !== null &&
+    typeof raw === 'object' &&
+    (raw as Record<string, unknown>).type === 'CreateEffort' &&
+    'cites' in raw
+  )
+    throw new EffortGraphValidationError(
+      'CreateEffort does not accept cites; create the Effort before its Citations.'
+    );
+  const input = EffortGraphMutationSchema.parse(raw);
   const cwd = options.cwd ?? process.cwd();
   const writer = createEffortGraphWriter({ rootDir: await rootFor(cwd) });
   const result = await writer.mutate(input);

--- a/packages/flatbread/src/effort/read.ts
+++ b/packages/flatbread/src/effort/read.ts
@@ -549,12 +549,12 @@ export async function effortRecords(
         'constraint',
         'risk',
         'citation',
-        'blob',
       ] as PrimitiveKind[]);
   const where = options.where ?? {};
-  // The generated relation field materializes as an object, so its `eq`
-  // comparator does not match the stored identifier. Scalar predicates still
-  // execute in Flatbread; effort ownership is normalized and intersected here.
+  // Default kinds include citation but omit blob (opt in via --kinds). The
+  // generated relation field materializes as an object, so its `eq` comparator
+  // does not match the stored identifier. Scalar predicates still execute in
+  // Flatbread; effort ownership is normalized and intersected here.
   const filter: Record<string, unknown> = {};
   if (where.state?.length) filter.state = { in: where.state };
   if (where.status?.length) filter.status = { in: where.status };
@@ -656,7 +656,11 @@ export async function relations(
   const source = collection
     ? await projection.one(collection, fromId)
     : undefined;
-  if (!source || source.frontmatter.effort !== effortId)
+  const sourceInEffort =
+    source?.kind === 'effort' && fromId === effortId
+      ? true
+      : source?.frontmatter.effort === effortId;
+  if (!source || !sourceInEffort)
     throw new Error(`Record ${fromId} does not exist in effort ${effortId}`);
   const selected = new Map<string, ReadRecord>();
   for (const relation of relationNames) {

--- a/packages/flatbread/src/graphql/liveServerEffortGraph.test.ts
+++ b/packages/flatbread/src/graphql/liveServerEffortGraph.test.ts
@@ -92,6 +92,51 @@ test.serial(
 );
 
 test.serial(
+  'Citation and Blob mutations are queryable through the live GraphQL bridge',
+  async (t) => {
+    const fixture = await makeDir();
+    t.teardown(() => rm(fixture.dir, { recursive: true, force: true }));
+    const server = await startGraphqlServer({
+      config: config(fixture.relativeRoot, true),
+      port: 0,
+    });
+    t.teardown(() => server.close());
+    const effort = await server.effortGraph!.writer.mutate({
+      type: 'CreateEffort',
+      title: 'GraphQL cite chain',
+      body: '',
+    });
+    const effortId = effort.artifacts[0].id;
+    const blob = await server.effortGraph!.writer.mutate({
+      type: 'WriteBlob',
+      effort: effortId,
+      title: 'Payload',
+      body: '# longform research\n',
+      kind: 'markdown',
+    });
+    const blobId = blob.artifacts[0].id;
+    const citation = await server.effortGraph!.writer.mutate({
+      type: 'WriteCitation',
+      effort: effortId,
+      title: 'Paper',
+      body: 'https://example.com/paper',
+      role: 'evidence',
+      blob: blobId,
+    });
+    await server.effortGraph!.waitForCommittedGeneration(citation.generation);
+    const response = await query(
+      server.port,
+      `{ allCitations { title blob { id title } } allBlobs { id title } }`
+    );
+    t.deepEqual(response.errors, undefined);
+    t.deepEqual(response.data?.allCitations, [
+      { title: 'Paper', blob: { id: blobId, title: 'Payload' } },
+    ]);
+    t.deepEqual(response.data?.allBlobs, [{ id: blobId, title: 'Payload' }]);
+  }
+);
+
+test.serial(
   'boot recovery completes a committed-unpublished transaction before listen',
   async (t) => {
     const fixture = await makeDir();


### PR DESCRIPTION
Follow-up to the Citation and Blob work in #224 and #225.

## What this PR changes
- Adds Citations as the records used to refer to outside sources.
- Lets a Citation optionally point to a Blob, which stores large content such as a document, JSON, or image.
- Ensures these links stay within the same Effort and covers the behavior in the planner, writer, CLI, and GraphQL.
- Updates skills, reference material, and example records so the workflow is explained in direct language.

## How to attach a source
1. Save large content with `WriteBlob` when needed.
2. Create a `WriteCitation` for the URL or source.
3. Create the Finding, Decision, Issue, Constraint, or Risk with `cites: ["<citation-id>"]`.

Create the Citation before the record that uses it; citations cannot be added later.

## Validation
- `pnpm -F @flatbread/effort-graph test` (104 passed)
- `pnpm exec ava packages/flatbread/src/cli/effort.test.ts packages/flatbread/src/graphql/liveServerEffortGraph.test.ts` (15 passed)
- `pnpm lint`
- `pnpm skills:check`