### PR TITLE
fix(explorer): restore monorepo path aliases for typecheck

### DIFF
--- a/packages/explorer/tsconfig.json
+++ b/packages/explorer/tsconfig.json
@@ -2,14 +2,33 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
     "noEmit": true,
     "ignoreDeprecations": "6.0",
+    "skipLibCheck": true,
     "types": ["node"],
-    "baseUrl": ".",
+    "baseUrl": "../..",
     "paths": {
-      "@/*": ["./src/web/*"]
+      "@/*": ["./packages/explorer/src/web/*"],
+      "flatbread": ["./packages/flatbread/src/index.ts"],
+      "@flatbread/codegen": ["./packages/codegen/src/index.ts"],
+      "@flatbread/core": ["./packages/core/src/index.ts"],
+      "@flatbread/config": ["./packages/config/src/index.ts"],
+      "@flatbread/proof": ["./packages/proof/src/index.ts"],
+      "@flatbread/resolver-svimg": ["./packages/resolver-svimg/src/index.ts"],
+      "@flatbread/utils": ["./packages/utils/src/index.ts"],
+      "@flatbread/explorer": ["./packages/explorer/src/node/index.ts"],
+      "@flatbread/effort-graph": ["./packages/effort-graph/src/index.ts"],
+      "@flatbread/source-filesystem": [
+        "./packages/source-filesystem/src/index.ts"
+      ],
+      "@flatbread/transformer-markdown": [
+        "./packages/transformer-markdown/src/index.ts"
+      ],
+      "@flatbread/transformer-yaml": [
+        "./packages/transformer-yaml/src/index.ts"
+      ]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],


### PR DESCRIPTION
Explorer tsconfig overrode root `paths` with only `@/*`, so
`@flatbread/effort-graph` was invisible during CI typecheck
(before build). Re-declare the monorepo path map, raise `lib` to
ESNext, and set `skipLibCheck` so transitive source resolves cleanly.

Depends-On: #230