### PR TITLE
release: prepare Flatbread 1.0

### DIFF
--- a/.agents/skills/effort-graph/release.json
+++ b/.agents/skills/effort-graph/release.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "flatbreadVersion": "1.0.0-alpha.22",
-  "effortGraphVersion": "0.1.0-alpha.0",
-  "gitTag": "v1.0.0-alpha.22"
+  "flatbreadVersion": "1.0.0",
+  "effortGraphVersion": "1.0.0",
+  "gitTag": "v1.0.0"
 }

--- a/.flatbread-efforts/decisions/dec-keep-effort-graph-secondary-with-a-primary-wedge--estattvqnhffm2dc.md
+++ b/.flatbread-efforts/decisions/dec-keep-effort-graph-secondary-with-a-primary-wedge--estattvqnhffm2dc.md
@@ -2,10 +2,12 @@
 id: dec-keep-effort-graph-secondary-with-a-primary-wedge--estattvqnhffm2dc
 effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
 title: Keep Effort Graph secondary with a primary-wedge gate
-state: accepted
+state: superseded
 created_at: '2026-07-18T19:43:02.802Z'
 derives_from:
   - fnd-filtered-retrieval-is-94-percent-smaller--qpvz4vch5hygye20
+superseded_by:
+  - dec-lead-flatbread-1-0-with-effort-graph-agent-memor--nhxsqm8sd43s2avx
 ---
 
 Keep the graph as a strong candidate secondary vertical rather than displacing

--- a/.flatbread-efforts/decisions/dec-lead-flatbread-1-0-with-effort-graph-agent-memor--nhxsqm8sd43s2avx.md
+++ b/.flatbread-efforts/decisions/dec-lead-flatbread-1-0-with-effort-graph-agent-memor--nhxsqm8sd43s2avx.md
@@ -1,0 +1,21 @@
+---
+id: dec-lead-flatbread-1-0-with-effort-graph-agent-memor--nhxsqm8sd43s2avx
+effort: eff-effort-graph-memory-and-agent-wedge--szeqvmgqjqnhd002
+title: Lead Flatbread 1.0 with Effort Graph agent memory
+state: accepted
+created_at: '2026-07-29T10:43:48.897Z'
+supersedes:
+  - dec-keep-effort-graph-secondary-with-a-primary-wedge--estattvqnhffm2dc
+---
+
+## Context
+
+Flatbread 1.0 is the first stable npm release. The release brief asks the public docs and package copy to lead with the utility already shipped through Effort Graph, while keeping Flatbread useful for general static relational content.
+
+## Decision
+
+Lead Flatbread 1.0 positioning with Effort Graph as Git-native memory for coding agents. Present static relational content for sites, docs, and internal tools as a first-class general use. Keep GraphQL and generated TypeScript as read interfaces over the graph, not the product identity.
+
+## Consequences
+
+The root README, npm descriptions, positioning guide, and release notes use this hierarchy. The release does not add a hosted CMS, semantic search, general writes, or a new runtime contract. Proof remains workflow tooling rather than the memory product. Revisit this lead only when user evidence shows another use case explains Flatbread more clearly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+Notes for the Flatbread release train. Some packages also keep their own
+changelog; this file covers the repository as a whole.
+
+## 1.0.0
+
+First stable release. The alpha train ended at `flatbread@1.0.0-alpha.22`.
+
+Twelve packages make up the 1.0 release set. They all ship at `1.0.0` and move
+in lockstep from here. One version number across the set, so you no longer have
+to work out which alpha of one package matches which alpha of another.
+
+Nine were already on npm as alphas and go to `1.0.0` from there:
+
+`flatbread`, `@flatbread/core`, `@flatbread/config`, `@flatbread/codegen`,
+`@flatbread/resolver-svimg`, `@flatbread/source-filesystem`,
+`@flatbread/transformer-markdown`, `@flatbread/transformer-yaml`, and
+`@flatbread/utils`.
+
+Three reach npm for the first time in this release:
+
+- `@flatbread/effort-graph` writes and reads agent memory records.
+- `@flatbread/explorer` serves the single-page app for browsing a content graph.
+- `@flatbread/proof` runs a task DAG of Cursor subagents.
+
+### Packaging
+
+- Every package declares `engines.node: ">=20.19"`. The old floors were
+  `^14.13.1 || >=16.0.0`, `>=18`, and in several packages nothing at all. Node
+  18, and Node 20 before 20.19, are no longer supported.
+- `@flatbread/config` declares `@flatbread/core` as a runtime dependency. It
+  was a devDependency, which worked inside this monorepo and nowhere else.
+- `@flatbread/codegen` widens its peer range on `@flatbread/config` and
+  `@flatbread/core` from `workspace:*` to `workspace:^`, so it publishes a
+  caret range instead of an exact pin.
+- `@flatbread/resolver-svimg` points its `repository`, `homepage`, and `bugs`
+  links at `FlatbreadLabs/flatbread`. They still named the old
+  `tonyketcham/flatbread` fork.
+- Every package carries a description that says what that package does.
+
+### Docs
+
+- The READMEs and `docs/positioning.md` now lead with the Effort Graph: an
+  agent's Efforts, Issues, Findings, Decisions, Constraints, Risks, Citations,
+  and Blobs written as Markdown records in your repository. The reasoning gets
+  committed and reviewed like the code.
+- Relational content for sites, docs, and internal tools stays a first-class
+  second path on the same engine, and GraphQL is described as one read
+  interface over the graph rather than as the product.
+- Removed the banner that called the whole project experimental. The narrower
+  qualifiers still hold: the generated TypeScript read API is a prototype, and
+  its selection-string escape hatch is experimental.
+- The `@flatbread/effort-graph` README no longer claims Git ignores the journal
+  for you. It names the default `.flatbread-efforts` root, lists the two
+  `.gitignore` lines you must add, and points at
+  `flatbread effort bootstrap --verify`, which exits nonzero when setup is
+  incomplete.
+
+There is no migration guide. Of the changes above, the Node floor is the one
+that can break an install. For anything else that moved since
+`1.0.0-alpha.22`, read the Git history; the alpha train did not keep
+per-release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,20 @@ There are two steps:
 1. Bump versions where there are changes
 2. Publish the changed packages
 
+### One-time note for 1.0
+
+The 1.0 release put every published package on `1.0.0` at once, rather than
+letting each package carry its own alpha number. `pnpm bump` still works the
+same way: it preselects the packages that changed plus their workspace
+dependents. Only bump every package together again when a release calls for it.
+
+`packages/effort-graph/skills/effort-graph/release.json` records the version an
+end user installs. Edit that file, not the copy in `.agents/`. Then run
+`pnpm skills:sync` to refresh the `.agents/` copy and `pnpm skills:pack-check`,
+which fails unless `flatbreadVersion` and `effortGraphVersion` match the current
+`package.json` versions and `gitTag` equals `v<flatbreadVersion>`. `pnpm verify`
+runs both checks.
+
 ### 1) Bump versions only where there are changes
 
 Use the interactive bump script:
@@ -189,7 +203,8 @@ Details:
   deleted after publication.
 
 End users install the skill from that release tag and install the matching
-`flatbread` version:
+`flatbread` version. Replace `X` with the released version — `1.0.0` for the
+first stable release, so the tag is `v1.0.0`:
 
 ```bash
 npx skills add https://github.com/FlatbreadLabs/flatbread/tree/vX/packages/effort-graph/skills/effort-graph --skill effort-graph

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Flatbread contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -6,15 +6,39 @@ To compare Flatbread with databases, CMSs, and other file-based tools, see
 [Comparing Flatbread with other tools](./pmf-decision-rubric.md). For keeping
 and moving your data, see [data ownership](./data-ownership.md).
 
-Turn files in Git into typed, related content for your TypeScript app. A
-Flatbread project has collections, records, and `refs` that link records.
-Generated types and [GraphQL](https://graphql.org/) operations are common ways
-for an app to read that data; they do not define what Flatbread is.
+Flatbread turns files in Git into a typed relational graph. A project has
+collections, records, and `refs` that link records. Generated types and
+[GraphQL](https://graphql.org/) operations are common ways for an app to read
+that graph; they do not define what Flatbread is.
 
 **Flatbread** reads content from your repository and file system. Plugins
 control how it reads files and turns them into data.
 
-**Who it is for:** Teams building TypeScript sites, internal tools, and starter
+## The lead use case: memory for coding agents
+
+The [Proof](../packages/proof/README.md) is a Flatbread content
+model for what a coding agent works out along the way. An agent records an
+Effort and then writes Issues, Findings, Decisions, Constraints, Risks,
+Citations, and Blobs against it. Each record is a markdown file under
+`.flatbread-proof/`, so it is committed, diffed, reviewed, and reverted like
+source. Writes go through `flatbread proof write`; reads come back as bounded
+digests from `flatbread proof list`, `flatbread proof records`,
+`flatbread proof relations`, `flatbread proof blocking-decisions`, and
+`flatbread proof get`.
+
+That solves a plain problem: an agent that closes its session forgets why it
+chose what it chose. Putting the reasoning in the repository keeps it next to
+the code it explains, and keeps it readable by a person.
+
+## The general case: relational content
+
+Everything above is one content model on a general engine. The same
+collections, `refs`, filters, and generated types back sites, docs, and
+internal tools. Posts point at authors; authors point at each other. Model your
+own collections and you get the same typed graph.
+
+**Who it is for:** People building coding agents that need memory a human can
+review in Git, and teams building TypeScript sites, internal tools, and starter
 projects that want versioned, reviewable content and links between entries
 without setting up a CMS database.
 
@@ -23,13 +47,15 @@ without setting up a CMS database.
 - It is not a hosted CMS, dashboard, or writing UI.
 - It is not a general-purpose GraphQL platform or database. Transactions,
   detailed access control, and many concurrent writers are outside its scope.
-- [`flatbread start --watch`](./local-dev-loop.md) reloads valid content and
-  config changes. Changes to Flatbread packages still need their own rebuild or
+- It does not reload its own packages.
+  [`flatbread start --watch`](./local-dev-loop.md) picks up valid content and
+  config changes, but a change to a Flatbread package needs a rebuild and a
   restart.
 
-**GraphQL:** In the default setup, GraphQL reads data that Flatbread has already
-loaded (`schema → operations → codegen`). Start with files and configuration,
-then choose how your app reads the data. The
+**GraphQL:** GraphQL is one read interface over the graph. In the default setup
+it reads data that Flatbread has already loaded, following
+`schema → operations → codegen`. Start with files and configuration, then
+choose how your app reads the data. The
 [Quickstart](../packages/flatbread/README.md#quickstart-posts-authors-and-tags)
 shows posts, authors, and tags from files through generated types.
 

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -1,154 +1,49 @@
 # @flatbread/codegen
 
+## 1.0.0
+
+First stable release, published in lockstep with the rest of Flatbread at
+`1.0.0`.
+
+- Requires Node 20.19 or newer (`engines.node: ">=20.19"`).
+- The peer range on `@flatbread/config` and `@flatbread/core` moves from
+  `workspace:*` to `workspace:^`, so the published package asks for a caret
+  range instead of an exact version.
+- Besides GraphQL schema and operation types, the generated file now contains a
+  prototype TypeScript read API, `createFlatbreadReadApi()`, built from your
+  configured collections, fields, and refs. It runs its reads through the
+  GraphQL layer, and its selection-string escape hatch is experimental.
+
+Current defaults:
+
+- Output: `./generated/graphql.ts`
+- Plugins: `typescript`, `typescript-operations`, `typed-document-node`, or
+  pick a `preset` of `basic`, `operations`, or `full`
+- Caching: on
+- Schema: deprecated fields included, introspection excluded
+
+CLI:
+
+```bash
+flatbread codegen                 # generate once
+flatbread codegen --watch         # regenerate when files change
+flatbread codegen --clear-cache   # force a full regeneration
+flatbread codegen --verbose       # log what it is doing
+```
+
+Versions between `1.0.0-alpha.1` and `1.0.0` were part of the alpha train and
+have no separate notes.
+
 ## 1.0.0-alpha.1
 
-### 🎉 Initial Release
+Initial release.
 
-- **New package** for automatic TypeScript type generation from Flatbread GraphQL schemas
-- **GraphQL Code Generator integration** with intelligent caching and hashing
-- **CLI support** via `npx flatbread codegen` command
-- **Comprehensive configuration options** including plugin customization
-- **Framework-agnostic design** supporting React, Vue, Angular, Next.js, SvelteKit, and more
-
-### ✨ Features
-
-- **5 Codegen Strategies Analyzed**: Evaluated GraphQL Code Generator, gql.tada, GraphQL Request + React Query, Shopify's graphql-codegen, and urql + codegen
-- **Intelligent Caching**: Avoid regeneration when Flatbread config and schema haven't changed
-- **Hash-based Change Detection**: Uses SHA256 hashing of config, schema, and documents
-- **Plugin System**: Full support for GraphQL Code Generator's extensive plugin ecosystem
-- **Type Safety**: Generated TypeScript types for queries, mutations, and subscriptions
-- **CLI Integration**: Seamless integration with existing `flatbread` CLI
-- **Watch Mode**: Automatic regeneration on file changes
-- **Cache Management**: Manual cache clearing and invalidation options
-
-### 🏗️ Architecture
-
-- **Modular Design**: Separate modules for hashing, caching, generation, and CLI
-- **Peer Dependencies**: Lightweight integration with existing Flatbread packages
-- **TypeScript-first**: Full TypeScript support with comprehensive type definitions
-- **Testing**: Comprehensive test suite with vitest
-
-### 📦 API
-
-#### Configuration
-
-```ts
-interface CodegenOptions {
-  enabled?: boolean;
-  outputDir?: string;
-  outputFile?: string;
-  plugins?: string[];
-  codegenConfig?: Partial<CodegenConfig>;
-  pluginConfig?: Record<string, Record<string, any>>;
-  watch?: boolean;
-  cache?: boolean;
-  documents?: string[];
-  schema?: {
-    includeIntrospection?: boolean;
-    includeDeprecated?: boolean;
-  };
-}
-```
-
-#### Core Functions
-
-- `generateTypes()` - Generate TypeScript types from GraphQL schema
-- `generateTypesWithDocuments()` - Include GraphQL documents in generation
-- `watchAndGenerate()` - Watch mode for automatic regeneration
-- `hashCodegenInputs()` - Generate hash for change detection
-- `loadCache()` / `saveCache()` - Cache management
-
-#### CLI Commands
-
-```bash
-npx flatbread codegen                    # Generate types
-npx flatbread codegen --watch            # Watch mode
-npx flatbread codegen --clear-cache      # Force regeneration
-npx flatbread codegen --verbose          # Detailed logging
-```
-
-### 🎯 Default Configuration
-
-- **Plugins**: `['typescript', 'typescript-operations', 'typed-document-node']`
-- **Output**: `./src/generated/graphql.ts`
-- **Caching**: Enabled by default
-- **Schema Options**: Include deprecated fields, exclude introspection
-
-### 🤝 Framework Support
-
-- **React**: Apollo Client, urql, React Query
-- **Vue**: Vue Apollo, urql
-- **Angular**: Apollo Angular
-- **Next.js**: SSG/SSR with GraphQL Request
-- **SvelteKit**: Load functions with GraphQL Request
-- **Node.js**: Server-side GraphQL clients
-
-### 📚 Documentation
-
-- **Comprehensive README** with usage examples and configuration options
-- **Comparative Analysis** of 5 different GraphQL codegen approaches
-- **Framework Integration** guides for popular frontend frameworks
-- **Troubleshooting** section with common issues and solutions
-
-### 🧪 Testing
-
-- **Hash Functions**: Comprehensive tests for configuration and schema hashing
-- **Type Definitions**: Tests for default options and type safety
-- **Vitest Integration**: Modern testing framework with TypeScript support
-
-### 🔄 Dependencies
-
-- **@graphql-codegen/cli**: ^5.0.0
-- **@graphql-codegen/typescript**: ^4.1.6
-- **@graphql-codegen/typescript-operations**: ^4.2.0
-- **@graphql-codegen/typed-document-node**: ^2.3.0
-- **@graphql-typed-document-node/core**: ^3.1.0
-- **fs-extra**: ^11.1.0
-- **kleur**: ^4.1.5
-
-### 🎨 Examples
-
-- **Next.js Configuration**: Complete example with codegen configuration
-- **GraphQL Documents**: Sample queries and mutations for type generation
-- **Framework Integration**: Examples for multiple frontend frameworks
-
-### ⚡ Performance
-
-- **Zero Runtime Overhead**: Generated types are compile-time only
-- **Intelligent Caching**: Skip regeneration when nothing has changed
-- **Fast Hashing**: SHA256-based change detection
-- **Incremental Builds**: Only regenerate when necessary
-
-### 🏃‍♂️ Getting Started
-
-1. Add to your `flatbread.config.ts`:
-
-```ts
-export default defineConfig({
-  // ... your existing config
-  codegen: {
-    enabled: true,
-    outputDir: './src/generated',
-    outputFile: 'graphql.ts',
-  },
-});
-```
-
-2. Generate types:
-
-```bash
-npx flatbread codegen
-```
-
-3. Use in your app:
-
-```ts
-import type { Post, GetPostsQuery } from './generated/graphql';
-```
-
-### 🔮 Future Plans
-
-- **gql.tada Integration**: Support for compile-time type inference
-- **Custom Strategies**: Plugin system for alternative codegen approaches
-- **IDE Integration**: VS Code extension for seamless development experience
-- **Performance Monitoring**: Built-in performance metrics and optimization suggestions
+- Generates TypeScript from a Flatbread GraphQL schema with
+  [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen).
+- Adds the `flatbread codegen` command, including `--watch`, `--clear-cache`,
+  and `--verbose`.
+- Skips regeneration when nothing changed, comparing SHA256 hashes of the
+  config, schema, and documents.
+- Exposes `generateTypes()`, `generateTypesWithDocuments()`,
+  `watchAndGenerate()`, `hashCodegenInputs()`, `loadCache()`, and `saveCache()`.
+- Reads its settings from the `codegen` key in `flatbread.config.*`.

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/codegen",
-  "version": "1.0.0-alpha.2",
-  "description": "Automatic TypeScript type generation for Flatbread GraphQL schemas",
+  "version": "1.0.0",
+  "description": "Generates TypeScript types, typed document nodes, and a prototype read API from a Flatbread content model.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -29,6 +29,9 @@
     "dist",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
     "@flatbread/utils": "workspace:*",
     "@graphql-codegen/cli": "^5.0.7",
@@ -50,8 +53,8 @@
     "vitest": "^4.1.5"
   },
   "peerDependencies": {
-    "@flatbread/config": "workspace:*",
-    "@flatbread/core": "workspace:*",
+    "@flatbread/config": "workspace:^",
+    "@flatbread/core": "workspace:^",
     "@graphql-typed-document-node/core": "^3.1.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/config",
-  "version": "1.0.0-alpha.9",
-  "description": "Flatbread's user config processing",
+  "version": "1.0.0",
+  "description": "Loads, validates, and types flatbread.config.* files. Provides defineConfig().",
   "type": "module",
   "publishConfig": {
     "main": "dist/index.js",
@@ -35,11 +35,14 @@
     "dist",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
+    "@flatbread/core": "workspace:*",
     "esbuild": "0.15.1"
   },
   "devDependencies": {
-    "@flatbread/core": "workspace:*",
     "@types/node": "16.11.47",
     "tsup": "6.2.1",
     "typescript": "4.7.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/core",
-  "version": "1.0.0-alpha.16",
-  "description": "Flatbread's essential logic",
+  "version": "1.0.0",
+  "description": "Flatbread's engine: runs source and transformer plugins, validates records and refs, and builds the GraphQL schema plus JSON and CSV snapshots.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -28,6 +28,9 @@
     "dist",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
     "graphql": "16.5.0",
     "graphql-compose": "9.0.8",

--- a/packages/effort-graph/README.md
+++ b/packages/effort-graph/README.md
@@ -1,20 +1,58 @@
 # `@flatbread/effort-graph`
 
-This package writes Flatbread Effort Graph records to Markdown files in your
-repository. It uses a journal so a change that affects several files either
-finishes completely or is undone.
+Git-native memory for coding agents. Installing this package gives you three
+things:
+
+- **Record types.** An agent records the work it is doing as an **Effort**,
+  then writes what it learns against that Effort: **Issues**, **Findings**,
+  **Decisions**, **Constraints**, **Risks**, **Citations**, and **Blobs**.
+- **Write operations.** A typed mutation turns into Markdown files on disk, and
+  the writer checks the links between records before it commits them.
+- **A Flatbread content model.** `effortGraphContent()` adds those eight record
+  types to a Flatbread configuration, so the same files come back as a typed
+  graph you can query and page through.
+
+Every record is a Markdown file in your repository, so you commit, diff,
+review, and revert an agent's reasoning the same way you handle code, and the
+next session can read it back.
+
+Writes go through a journal, so a change that touches several files either
+finishes in full or leaves nothing behind: if the process dies mid-write, the
+next run restores the earlier contents of the unfinished change.
 
 Version 1 supports these actions: `CreateEffort`, `SetEffortStatus`,
 `WriteIssue`, `WriteFinding`, `WriteDecision`, `WriteConstraint`, `WriteRisk`,
 `WriteCitation`, `WriteBlob`, `Supersede`, `Invalidate`, `ResolveIssue`,
 `AcceptDecision`, `MitigateRisk`, and `SetRiskState`.
 
-The journal is stored in `<root>/.journal` and is ignored by Git. Use
-`effortGraphContent()` to add Efforts, Issues, Findings, Decisions,
-Constraints, Risks, Citations, and Blobs to a Flatbread configuration. The
-writer checks links between those record types. Epistemic records may
-optionally `cites` Citation ids (Flatbread `refs`). A Citation body alone is
-valid (e.g. a URL); an optional `blob` ref attaches a longform payload.
+An Issue, Finding, Decision, Constraint, or Risk may name Citation ids in
+`cites` (Flatbread `refs`). A Citation body alone is valid (e.g. a URL); an
+optional `blob` ref attaches a long payload such as a document, JSON, or image.
+
+## Where records live, and what to ignore
+
+`effortGraphContent()` stores the graph under `.flatbread-efforts` in your
+project root. Pass a path to choose another root:
+`effortGraphContent('path/to/graph')`.
+
+Two paths hold working state that Git should not track: the write journal at
+`<root>/.journal`, and the derived read cache at
+`.flatbread/effort-graph/read-cache`. Nothing adds them to `.gitignore` for
+you, so add these lines yourself:
+
+```gitignore
+**/.flatbread-efforts/.journal/
+**/.flatbread/effort-graph/read-cache/
+```
+
+For a custom root, replace `.flatbread-efforts` with that root. The read cache
+path stays the same.
+
+`flatbread effort bootstrap` reports what is still missing — the config entry
+or either ignore rule. `flatbread effort bootstrap --verify` reports the same
+and exits nonzero when anything is missing, which makes it usable in CI.
+
+## The domain model and the packaged skill
 
 Read [`skills/effort-graph/glossary.md`](./skills/effort-graph/glossary.md) for
 the portable Effort Graph domain model.
@@ -28,10 +66,10 @@ The packaged Agent Skill is in `skills/effort-graph/`. The repository copy in
 Install from a release tag, then activate the skill for setup:
 
 ```bash
-npx skills add https://github.com/FlatbreadLabs/flatbread/tree/vX/packages/effort-graph/skills/effort-graph --skill effort-graph
-npm install --save-dev flatbread@X
+npx skills add https://github.com/FlatbreadLabs/flatbread/tree/<gitTag>/packages/effort-graph/skills/effort-graph --skill effort-graph
+npm install --save-dev flatbread@<flatbreadVersion>
 ```
 
-Replace the placeholders with `gitTag` and `flatbreadVersion` from
-`skills/effort-graph/release.json`. See `skills/effort-graph/setup.md` for
+The tag and version come from `gitTag` and `flatbreadVersion` in
+`skills/effort-graph/release.json`. See `skills/effort-graph/setup.md` for the
 equivalent `pnpm`, `yarn`, and `bun` commands.

--- a/packages/effort-graph/package.json
+++ b/packages/effort-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/effort-graph",
-  "version": "0.1.0-alpha.0",
-  "description": "Standalone semantic writer for the Flatbread Effort Graph — journaled multi-file mutations over epistemic markdown artifacts.",
+  "version": "1.0.0",
+  "description": "Git-native memory records for coding agents. Writes typed Effort, Issue, Finding, Decision, Constraint, Risk, Citation, and Blob records to Markdown as journaled changes, and reads them back in bounded pages.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -34,12 +34,15 @@
     "skills",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
+    "@flatbread/core": "workspace:*",
     "gray-matter": "^4.0.3",
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@flatbread/core": "workspace:*",
     "@flatbread/transformer-markdown": "workspace:*",
     "@types/node": "25.6.2",
     "tsup": "8.5.1",

--- a/packages/effort-graph/skills/effort-graph/release.json
+++ b/packages/effort-graph/skills/effort-graph/release.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "flatbreadVersion": "1.0.0-alpha.22",
-  "effortGraphVersion": "0.1.0-alpha.0",
-  "gitTag": "v1.0.0-alpha.22"
+  "flatbreadVersion": "1.0.0",
+  "effortGraphVersion": "1.0.0",
+  "gitTag": "v1.0.0"
 }

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/explorer",
-  "version": "0.1.0-alpha.0",
-  "description": "Content-relation explorer SPA for Flatbread — generic graph shell with Effort Graph as the first preset.",
+  "version": "1.0.0",
+  "description": "Single-page app for browsing a Flatbread content graph, served by flatbread start. Ships an Effort Graph preset.",
   "type": "module",
   "scripts": {
     "build": "pnpm build:node && pnpm build:web",
@@ -32,6 +32,9 @@
     "dist",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
     "@flatbread/effort-graph": "workspace:*"
   },

--- a/packages/flatbread/README.md
+++ b/packages/flatbread/README.md
@@ -16,30 +16,49 @@
   </a>
 </p>
 
-Turn files in Git into typed, related content for your TypeScript app.
-**[GraphQL](https://graphql.org/)** and codegen are common ways to read that
-content, but they are not the only options. See
-[Flatbread positioning](https://github.com/FlatbreadLabs/flatbread/blob/main/docs/positioning.md).
+Flatbread turns files in Git into a typed relational graph. Files are the
+records. `refs` in `flatbread.config.js` link them. You read the graph through
+**[GraphQL](https://graphql.org/)**, generated TypeScript, or the `flatbread`
+CLI.
 
-**Flatbread** reads content from your repository and file system. Plugins control
-how it reads files and turns them into data.
+People use it two ways.
 
-**Who it is for:** Teams building TypeScript sites, internal tools, and starter
-projects that want versioned, reviewable content and links between entries
-without setting up a CMS database.
+**Durable memory for coding agents.** The
+[Effort Graph](https://github.com/FlatbreadLabs/flatbread/tree/main/packages/effort-graph)
+stores an agent's reasoning as markdown records in the repository: Efforts,
+Issues, Findings, Decisions, Constraints, Risks, Citations, and Blobs. An agent
+writes them with `flatbread effort write` and reads them back through bounded
+queries such as `flatbread effort list` and
+`flatbread effort blocking-decisions`. Records live under
+`.flatbread-efforts/`, so you commit, review, diff, and revert them like any
+other file, and the memory outlives the session that produced it. The bundled
+[Effort Graph skill](https://github.com/FlatbreadLabs/flatbread/blob/main/packages/effort-graph/skills/effort-graph/SKILL.md)
+teaches an agent the commands.
+
+**Relational content for sites, docs, and internal tools.** Markdown and YAML
+files become typed collections that link to each other. A post names its
+authors by id, and Flatbread resolves them. You get versioned, reviewable
+content and joins over files without a CMS database. Start with the
+[Quickstart](#quickstart-posts-authors-and-tags).
+
+Both paths run on the same engine. Plugins control how Flatbread reads files
+and turns them into data.
+
+**Who it is for:** People building coding agents that need memory they can
+review in Git, and teams building TypeScript sites, internal tools, and starter
+projects that want versioned content with links between entries.
 
 **What Flatbread does not do:**
 
 - It is not a hosted CMS, dashboard, or writing UI.
 - It is not a general-purpose GraphQL platform or database. Transactions,
   detailed access control, and many concurrent writers are outside its scope.
-- Run `flatbread start --watch` to update valid content and config changes
-  while you work. Changes to Flatbread packages still need their own rebuild or
-  restart. See the
+- It does not reload its own packages. `flatbread start --watch` picks up valid
+  content and config changes while you work, but a change to a Flatbread
+  package needs a rebuild and a restart. See the
   [local development loop](https://github.com/FlatbreadLabs/flatbread/blob/main/docs/local-dev-loop.md).
 
-**GraphQL:** GraphQL is a common way to read Flatbread data. It does not define
-the product. For more detail, see
+**GraphQL:** GraphQL is one read interface over the graph. For more detail, see
 [Flatbread positioning](https://github.com/FlatbreadLabs/flatbread/blob/main/docs/positioning.md).
 
 **Glossary:** Definitions for collections, relations, IDs, validation, and the
@@ -58,11 +77,10 @@ introspection, and generated TypeScript remain available when you move away
 from Flatbread. See
 [data ownership](https://github.com/FlatbreadLabs/flatbread/blob/main/docs/data-ownership.md).
 
-For contributing to this monorepo, use Node 20.19+ with pnpm 10.33.x. Runtime support for published packages is tracked by each package's own metadata.
+Every published package requires Node 20.19 or newer. To work on this monorepo,
+use Node 20.19+ with pnpm 10.33.x.
 
 ## Quickstart (posts, authors, and tags)
-
-🚧 This project is experimental; the API may change before `v1.0`.
 
 Start with the **Next.js example** in `examples/nextjs`. It reads shared
 Markdown from `examples/content` through its `content/` symlink. The commands
@@ -111,7 +129,7 @@ The Next example points `flatbread.config.js` at `content/markdown/...` **relati
 
 ### Traceability: same relation model (files, config, query interface)
 
-The table below ties the **Git-native** model to the default **GraphQL** read layer without implying GraphQL is the product’s whole identity—GraphQL is one [**query interface**](https://github.com/FlatbreadLabs/flatbread/blob/main/docs/glossary.md#query-interface); files and config remain the source of truth.
+The table below follows one relation from files to config to the generated GraphQL schema. Files and config are the source of truth; GraphQL is one [query interface](https://github.com/FlatbreadLabs/flatbread/blob/main/docs/glossary.md#query-interface) over them.
 
 | Layer                                     | You see…                                                                                                                         | Glossary                                                                                                                                                                                                                                                                                                         |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -173,20 +191,20 @@ query GetPostsAuthorsAndTags {
 }
 ```
 
-After codegen, your app imports types from **`./generated/graphql`**. The **result shape** of that operation is typed (for example **`GetPostsAuthorsAndTagsQuery`**)—relations resolve to **`Author`** objects while **`tags`** stay a **string array** on **`Post`**, matching the file metadata—the same row as the [illustrative JSON](#traceability-same-relation-model-files-config-query-interface) under **Traceability**.
+After codegen, your app imports types from **`./generated/graphql`**. The result shape of that operation is typed, for example **`GetPostsAuthorsAndTagsQuery`**. Relations resolve to **`Author`** objects; **`tags`** stays a string array on **`Post`**, matching the file metadata. That is the same shape as the [illustrative JSON](#traceability-same-relation-model-files-config-query-interface) under **Traceability**.
 
-The generated file also exposes a prototype **TypeScript read API** derived from the configured content model. In the Next.js example, [`examples/nextjs/lib/read.ts`](https://github.com/FlatbreadLabs/flatbread/blob/main/examples/nextjs/lib/read.ts) wires **`createFlatbreadReadApi()`** to the existing GraphQL fetcher and reads **posts**, **authors**, and **tags** with a generated default selection—no hand-written GraphQL document at the call site.
+The generated file also exposes a prototype **TypeScript read API** derived from the configured content model. In the Next.js example, [`examples/nextjs/lib/read.ts`](https://github.com/FlatbreadLabs/flatbread/blob/main/examples/nextjs/lib/read.ts) wires **`createFlatbreadReadApi()`** to the existing GraphQL fetcher. It reads **posts**, **authors**, and **tags** with a generated default selection, so there is no hand-written GraphQL document at the call site.
 
 #### Choosing a read interface
 
-Flatbread starts with related content files for TypeScript apps. Files define
-records, frontmatter fields, IDs, and `refs`; `flatbread.config.js` tells
-Flatbread how to group them into typed collections. **GraphQL** and the
-generated TypeScript API are two ways for your app to read the same data.
+Files come first. They define records, frontmatter fields, IDs, and `refs`;
+`flatbread.config.js` tells Flatbread how to group them into typed collections.
+**GraphQL** and the generated TypeScript API are two ways for your app to read
+the same data.
 
-Use **GraphQL operations** when your app needs explicit query documents, custom selections, Apollo or other GraphQL clients, persisted operations, or direct access to the GraphQL endpoint. Add `.graphql` documents, include fields like **`tags`** and **`authors`**, and rerun codegen so operation types such as **`GetPostsAuthorsAndTagsQuery`** match the posts/authors/tags graph.
+Use **GraphQL operations** when your app needs explicit query documents, custom selections, Apollo or another GraphQL client, persisted operations, or direct access to the GraphQL endpoint. Add `.graphql` documents, include fields like **`tags`** and **`authors`**, and rerun codegen so operation types such as **`GetPostsAuthorsAndTagsQuery`** match the posts/authors/tags graph.
 
-Use the prototype **generated TypeScript read API** when your app wants collection-shaped helpers for common reads from the configured Flatbread model, especially simple app reads such as posts, authors, tags, and resolved relations without writing GraphQL at each call site. The generated helpers currently execute through the GraphQL layer and still offer an experimental selection-string escape hatch, so both paths expose the same typed content graph backed by the same flat files while GraphQL remains the stable low-level interface.
+Use the prototype **generated TypeScript read API** when you want collection-shaped helpers instead of a GraphQL document at each call site. It suits plain reads: posts, authors, tags, and resolved relations. The helpers still run through the GraphQL layer, and their selection-string escape hatch is experimental. Both paths read the same typed graph from the same files; GraphQL is the stable lower-level interface.
 
 Default filesystem + markdown wiring uses the bundled [`source-filesystem`](https://github.com/FlatbreadLabs/flatbread/tree/main/packages/source-filesystem) and [`transformer-markdown`](https://github.com/FlatbreadLabs/flatbread/tree/main/packages/transformer-markdown) plugins (`flatbread` re-exports them).
 
@@ -219,7 +237,7 @@ export default defineConfig({
 
 ### 5 · Reading the graph: GraphQL (after the model exists)
 
-Flatbread builds a content **graph from files**. In the default toolchain, **GraphQL is one read interface**: schema + resolver shape over that graph—not “Flatbread is a GraphQL CMS.”
+Flatbread builds a content graph from files. GraphQL is one read interface over that graph: a generated schema and the resolvers behind it.
 
 Wire your framework so the CLI wraps dev/build (**`flatbread start`** passes through your command after **`--`**). There is **no** `flatbread dev` subcommand.
 
@@ -256,7 +274,7 @@ for the cases that still need a rebuild or restart.
 Outside this monorepo:
 
 ```bash
-pnpm add flatbread@latest
+pnpm add flatbread
 ```
 
 Scaffold **`flatbread.config.js`**:
@@ -270,13 +288,19 @@ Point **`content`** entries at **your** `posts/` and **`authors/`** folders, reu
 More detail on the bundled example is in the
 [Next.js example README](https://github.com/FlatbreadLabs/flatbread/blob/main/examples/nextjs/README.md).
 
+For agent memory instead of site content, add `effortGraphContent()` to your
+config, then run `flatbread effort bootstrap` to check the setup and
+`flatbread effort bootstrap --verify` to fail when something is missing. The
+[Effort Graph README](https://github.com/FlatbreadLabs/flatbread/blob/main/packages/effort-graph/README.md)
+has the install commands.
+
 ## Query arguments (GraphQL read interface)
 
 When **GraphQL** is your read interface, list fields use the following arguments in order of application.
 
 ### `filter`
 
-Each collection in the GraphQL schema can be passed a `filter` argument to constrain your results, sifting for only what you want. Any leaf field should be able to be used in a filter.
+Every collection in the GraphQL schema takes a `filter` argument that narrows the results. Any leaf field can be used in a filter.
 
 The syntax for `filter` is based on a subset of [MongoDB's query syntax](https://docs.mongodb.com/manual/reference/operator/query/).
 
@@ -354,7 +378,7 @@ Caveats:
 
 - Currently cannot infer date strings and then compare `Date` types in filters
   - should work if you dynamically pass in a `Date` object from your client, though not extensively tested
-  - if you wanna take a shot at that, start a PR for [adding arg typeOf checks and subsequent unique comparator functions 🥪](https://github.com/FlatbreadLabs/flatbread/blob/main/packages/core/src/utils/sift.ts)
+  - to fix this, add argument `typeof` checks and the matching comparator functions in [`packages/core/src/utils/sift.ts`](https://github.com/FlatbreadLabs/flatbread/blob/main/packages/core/src/utils/sift.ts), then open a pull request
 
 #### Combining multiple filters
 
@@ -382,7 +406,7 @@ result = [{ title: 'My pretzel collection' }];
 
 ### `sortBy`
 
-Sorts by the given field. Accepts a root-level field name. Defaults to not sortin' at all.
+Sorts by the given field. Accepts a root-level field name. Defaults to no sorting.
 
 ### `order`
 

--- a/packages/flatbread/package.json
+++ b/packages/flatbread/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flatbread",
-  "version": "1.0.0-alpha.22",
-  "description": "Consume relational, flat-file data using GraphQL 🥯 inside damn near any framework.",
+  "version": "1.0.0",
+  "description": "Git-native memory for coding agents and relational content for TypeScript apps. Files in your repo become a typed graph you read over GraphQL, generated TypeScript, or the CLI.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -30,6 +30,9 @@
     "dist",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
     "@apollo/server": "5.0.0",
     "@apollo/utils.keyvaluecache": "^4.0.0",

--- a/packages/proof/README.md
+++ b/packages/proof/README.md
@@ -1,241 +1,75 @@
-# Proof
+# `@flatbread/proof`
 
-Proof is Flatbread's DAG task runner for Cursor agents. It decomposes a task into a graph of subagents, runs each node in topological order, and writes a live `.canvas.tsx` so you can watch the work move from `PENDING` to `RUNNING` to `FINISHED` or `ERROR`.
+Git-native memory for coding agents. Installing this package gives you three
+things:
 
-The package ships as `@flatbread/proof` and exposes:
+- **Record types.** An agent records the work it is doing as an **Effort**,
+  then writes what it learns against that Effort: **Issues**, **Findings**,
+  **Decisions**, **Constraints**, **Risks**, **Citations**, and **Blobs**.
+- **Write operations.** A typed mutation turns into Markdown files on disk, and
+  the writer checks the links between records before it commits them.
+- **A Flatbread content model.** `proofContent()` adds those eight record
+  types to a Flatbread configuration, so the same files come back as a typed
+  graph you can query and page through.
 
-- `proof`: run a DAG or initialize its canvas.
-- `proof-supervisor`: run Proof in self-hosting mode so edits to `packages/proof/src/**` can be picked up between ranks.
-- Library exports for tooling that wants to author, validate, or inspect DAGs programmatically.
+Every record is a Markdown file in your repository, so you commit, diff,
+review, and revert an agent's reasoning the same way you handle code, and the
+next session can read it back.
 
-## Quick Start
+Writes go through a journal, so a change that touches several files either
+finishes in full or leaves nothing behind: if the process dies mid-write, the
+next run restores the earlier contents of the unfinished change.
 
-Build the package once after installing dependencies:
+Version 1 supports these actions: `CreateEffort`, `SetEffortStatus`,
+`WriteIssue`, `WriteFinding`, `WriteDecision`, `WriteConstraint`, `WriteRisk`,
+`WriteCitation`, `WriteBlob`, `Supersede`, `Invalidate`, `ResolveIssue`,
+`AcceptDecision`, `MitigateRisk`, and `SetRiskState`.
+
+An Issue, Finding, Decision, Constraint, or Risk may name Citation ids in
+`cites` (Flatbread `refs`). A Citation body alone is valid (e.g. a URL); an
+optional `blob` ref attaches a long payload such as a document, JSON, or image.
+
+## Where records live, and what to ignore
+
+`proofContent()` stores the graph under `.flatbread-proof` in your
+project root. Pass a path to choose another root:
+`proofContent('path/to/graph')`.
+
+Two paths hold working state that Git should not track: the write journal at
+`<root>/.journal`, and the derived read cache at
+`.flatbread/proof/read-cache`. Nothing adds them to `.gitignore` for
+you, so add these lines yourself:
+
+```gitignore
+**/.flatbread-proof/.journal/
+**/.flatbread/proof/read-cache/
+```
+
+For a custom root, replace `.flatbread-proof` with that root. The read cache
+path stays the same.
+
+`flatbread proof bootstrap` reports what is still missing — the config entry
+or either ignore rule. `flatbread proof bootstrap --verify` reports the same
+and exits nonzero when anything is missing, which makes it usable in CI.
+
+## The domain model and the packaged skill
+
+Read [`skills/proof/glossary.md`](./skills/proof/glossary.md) for
+the portable Proof domain model.
+
+The packaged Agent Skill is in `skills/proof/`. The repository copy in
+`.agents/skills/proof/` is generated from those files. Run
+`pnpm skills:sync` from the repository root after changing the skill.
+
+## Install the Proof skill
+
+Install from a release tag, then activate the skill for setup:
 
 ```bash
-pnpm -F @flatbread/proof build
+npx skills add https://github.com/FlatbreadLabs/flatbread/tree/<gitTag>/packages/proof/skills/proof --skill proof
+npm install --save-dev flatbread@<flatbreadVersion>
 ```
 
-Create a DAG JSON file:
-
-```json
-{
-  "title": "Build a tiny CLI todo app",
-  "tasks": [
-    {
-      "id": "design",
-      "depends_on": [],
-      "complexity": "LOW",
-      "subtask_prompt": "Design the minimal CLI commands and file layout."
-    },
-    {
-      "id": "implement",
-      "depends_on": ["design"],
-      "complexity": "MED",
-      "subtask_prompt": "Implement the todo CLI based on the design."
-    }
-  ]
-}
-```
-
-Initialize a canvas without requiring `CURSOR_API_KEY`:
-
-```bash
-pnpm exec proof \
-  --init-only \
-  --dag /tmp/example-dag.json \
-  --canvas-path /tmp/example-dag.canvas.tsx
-```
-
-Run the DAG:
-
-```bash
-export CURSOR_API_KEY=crsr_...
-
-pnpm exec proof \
-  --dag /tmp/example-dag.json \
-  --canvas-path /tmp/example-dag.canvas.tsx
-```
-
-## DAG Shape
-
-Every DAG has a `title` and a `tasks` array. Each task needs:
-
-- `id`: unique kebab-case task id.
-- `depends_on`: ids of parent tasks that must finish first.
-- `complexity`: `HIGH`, `MED`, or `LOW`; maps to a Cursor model.
-- `subtask_prompt`: standalone instructions for the subagent.
-
-Proof computes ranks with Kahn topological sort and runs sibling tasks in the same rank concurrently. Avoid placing two sibling tasks in the same rank if they write the same files.
-
-Optional top-level `models` can override the default complexity map with plain
-SDK model id strings or SDK model selections:
-
-```json
-{
-  "models": {
-    "HIGH": {
-      "id": "gpt-5.4",
-      "params": [{ "id": "reasoning", "value": "high" }]
-    },
-    "MED": "composer-2",
-    "LOW": {
-      "id": "gpt-5.4-nano",
-      "params": [{ "id": "reasoning", "value": "low" }]
-    }
-  }
-}
-```
-
-Use the object shape when you need `params`; use a string when the model id is
-enough. For example, use `{ "id": "gpt-5.4", "params": [{ "id": "reasoning", "value": "high" }] }`, not a suffix-style id like `gpt-5.4-high`.
-
-When a DAG runs, Proof calls `Cursor.models.list()`, validates model ids and
-param values, and expands partial selections to the closest valid SDK preset
-variant using that model's default variant for omitted params. `--init-only`
-does not call the SDK, so it can still render a canvas without `CURSOR_API_KEY`.
-
-Optional task kinds add control gates:
-
-- `kind: "oracle"` runs a shell command and records pass/fail evidence.
-- `kind: "pause"` waits for a checkpoint sentinel so a human can inspect or approve before downstream work continues.
-
-## `DAG.loops`
-
-Bounded convergence loops can live in the DAG itself instead of only on the CLI. This keeps the run reproducible: contributors do not need to remember a matching `--converge-on ... --max-iterations ...` flag pair.
-
-```json
-{
-  "title": "implement then review until clean",
-  "loops": [
-    {
-      "convergeOn": "review",
-      "maxIterations": 3,
-      "reexecute": { "kind": "tasks", "tasks": ["implement"] }
-    }
-  ],
-  "tasks": [
-    {
-      "id": "implement",
-      "depends_on": [],
-      "complexity": "MED",
-      "subtask_prompt": "Implement the feature."
-    },
-    {
-      "id": "review",
-      "depends_on": ["implement"],
-      "complexity": "HIGH",
-      "subtask_prompt": "Review the implementation. Use `## Blockers` and `## High-severity findings` when needed."
-    }
-  ]
-}
-```
-
-Notes:
-
-- Omit `id` to get the default `loop-<convergeOn>` id.
-- Omit `reexecute` to re-run the full ancestor cone, which matches the legacy CLI behavior.
-- `reexecute: { "kind": "tasks", "tasks": [...] }` must stay inside the convergence task's ancestor cone and be dependency-closed for every non-`convergeOn` task it names; invalid subsets fail fast during DAG parsing with the missing ancestor ids.
-- Parsed explicit rerun lists always include `convergeOn` itself, even if the authored JSON omits it.
-- `DAG.loops` and `--converge-on` are mutually exclusive. If the DAG already declares loops, remove the CLI flag instead of relying on precedence.
-- Multiple loops are allowed only when their re-execution sets are disjoint, so one loop cannot invalidate another loop's converged result later in the run.
-
-## Artifact Output
-
-By default, every **full DAG run** writes per-task markdown transcripts to a timestamped directory (not `--init-only`, which exits before artifact setup, and not `--dry-check-cmds`, which never enters the runner):
-
-```
-<repo-root>/.flatbread/artifacts/dag-<title-slug>-<timestamp>/
-  _dag.json      # The original DAG definition
-  _index.md      # Run summary: outcome, timings, and links to all transcripts
-  <task-id>.md   # Full agent output for each task (kind: task, oracle, or pause)
-  <task-id>.stream.txt   # Append-only assistant transcript mirror (`kind: task` only)
-```
-
-**Execution vs canvas:**
-
-- For `kind: "task"` only, stitched prompts, in-process convergence parsing (`--converge-on` / `DAG.loops`), `${task-id}.findings.json` payloads (`--findings-dir`), and `<task-id>.md` derive from an **execution-authoritative** transcript. Resumed runs can reconstruct that transcript when the same `--full-output-dir` is reused and `transcriptPath` points at `${task-id}.stream.txt`; otherwise legacy bounded `resultText` remains the fallback.
-- The inlined canvas payload snapshots only a **4000-character display tail** (`CANVAS_DISPLAY_CAP`) per task plus an optional **`transcriptPath`** when `${task-id}.stream.txt` is mirrored.
-- Author `DAG.outputPolicy.upstream` as `"full"` or `"summarize"` (default) to widen or keep the upstream excerpt policy; trims carry visible counted banners.
-- Downstream nodes are skipped with `ERROR` when any upstream is `ERROR` or `BUDGET-EXCEEDED`.
-
-Paths resolve from `--cwd` (defaults to the process working directory). The live canvas still defaults under `~/.cursor/projects/<workspace-slug>/canvases/` when using `--canvas` without `--canvas-path`.
-
-Previously, transcripts only appeared when you passed `--full-output-dir`; now they land under `.flatbread/` by default. Use `--no-artifacts` for opt-out, or `--full-output-dir` to redirect elsewhere.
-
-`--no-artifacts` suppresses transcripts, `_index.md`, and `_dag.json` only. **`--findings-dir` JSON sidecars use a separate path** — omit that flag (or point it elsewhere) if you need completely artifact-free output besides the canvas.
-
-To suppress artifact writing:
-
-```bash
-pnpm exec proof --dag /tmp/my.json --canvas-path /tmp/my.canvas.tsx --no-artifacts
-```
-
-To write artifacts to a custom path:
-
-```bash
-pnpm exec proof --dag /tmp/my.json --canvas-path /tmp/my.canvas.tsx \
-  --full-output-dir /path/to/my-artifacts/
-```
-
-## Project Skill
-
-The canonical Cursor skill entrypoint lives at:
-
-```text
-.cursor/skills/proof/SKILL.md
-```
-
-Use that skill when a request asks to decompose work, run subagents in parallel, or execute a task as a dependency graph. The legacy `.cursor/skills/dag-task-runner/SKILL.md` entry remains as a compatibility handoff and points to Proof.
-
-## Self-Hosting Mode
-
-When the DAG may edit Proof itself, use the supervisor:
-
-```bash
-pnpm exec proof-supervisor \
-  --dag /tmp/example-dag.json \
-  --canvas-path /tmp/example-dag.canvas.tsx \
-  --state-path /tmp/example-dag-state.json
-```
-
-The supervisor adds `--restart-on-runner-change`. If runtime files change after a rank, Proof persists state, exits with code `75`, and the supervisor resumes from the state file under the rebuilt runtime.
-
-Each supervisor-spawned runner picks a **new default** `.flatbread/artifacts/dag-<slug>-<timestamp>/` directory unless you pin **`--full-output-dir <path>` on the supervisor command** so every child inherits the same path.
-
-After editing `packages/proof/src/**`, rebuild before resuming packaged CLI runs:
-
-```bash
-pnpm -F @flatbread/proof build
-```
-
-## Useful Commands
-
-```bash
-pnpm -F @flatbread/proof typecheck
-pnpm -F @flatbread/proof build
-pnpm -F @flatbread/proof test
-pnpm test
-pnpm -F @flatbread/proof models:list
-pnpm exec proof --dry-check-cmds --dag .cursor/skills/proof/examples/example_dag.json
-```
-
-`pnpm -F @flatbread/proof test` is the focused bounded-loop suite. Root `pnpm test` also reaches that AVA file through `ava.config.js`.
-
-## Library API
-
-Proof also exposes helpers for tooling:
-
-```ts
-import {
-  computeRanks,
-  createModelSelectionResolver,
-  parseDAG,
-  resolveModelSelectionFromCatalog,
-  runDryCheck,
-  type DAG,
-  type TaskState,
-} from '@flatbread/proof';
-```
-
-The public API includes DAG parsing and rank computation, model resolution, canvas state types, convergence helpers, dry command checks, oracle and pause helpers, and self-hosting state utilities.
+The tag and version come from `gitTag` and `flatbreadVersion` in
+`skills/proof/release.json`. See `skills/proof/setup.md` for the
+equivalent `pnpm`, `yarn`, and `bun` commands.

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/proof",
-  "version": "0.1.0-alpha.0",
-  "description": "Decompose a task into a DAG of subagents and prove they did the work — live canvas, oracles, pause gates, and convergence loops.",
+  "version": "1.0.0",
+  "description": "Bounded DAG task runner for Cursor agents. Runs subagent tasks in topological order with a live canvas, oracle and pause gates, and bounded re-execution loops.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -41,7 +41,7 @@
     "*.d.ts"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19"
   },
   "dependencies": {
     "@cursor/sdk": "^1.0.9"

--- a/packages/resolver-svimg/package.json
+++ b/packages/resolver-svimg/package.json
@@ -1,18 +1,18 @@
 {
   "name": "@flatbread/resolver-svimg",
-  "version": "1.0.0-alpha.0",
-  "description": "use svimg as a flatbread field resolver",
+  "version": "1.0.0",
+  "description": "Flatbread field resolver that turns an image path into svimg attributes: responsive srcsets, WebP and AVIF variants, and a blurred placeholder.",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tonyketcham/flatbread.git",
+    "url": "git+https://github.com/FlatbreadLabs/flatbread.git",
     "directory": "packages/resolver-svimg"
   },
-  "homepage": "https://github.com/tonyketcham/flatbread/tree/main/packages/resolver-svimg#readme",
+  "homepage": "https://github.com/FlatbreadLabs/flatbread/tree/main/packages/resolver-svimg#readme",
   "author": "Adam Sparks <adamsparks92@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tonyketcham/flatbread/issues"
+    "url": "https://github.com/FlatbreadLabs/flatbread/issues"
   },
   "exports": {
     ".": "./dist/index.js"
@@ -29,7 +29,7 @@
     "dev": "tsup --watch src"
   },
   "engines": {
-    "node": "^14.13.1 || >=16.0.0"
+    "node": ">=20.19"
   },
   "peerDependencies": {
     "svimg": "^2.0.0 || ^3.0.0"

--- a/packages/source-filesystem/package.json
+++ b/packages/source-filesystem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/source-filesystem",
-  "version": "1.0.0-alpha.9",
-  "description": "Filesystem source for Flatbread",
+  "version": "1.0.0",
+  "description": "Flatbread source plugin that reads content files from directories on disk.",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "dev": "tsup --watch src"
   },
   "engines": {
-    "node": "^14.13.1 || >=16.0.0"
+    "node": ">=20.19"
   },
   "dependencies": {
     "lodash-es": "^4.17.21",

--- a/packages/transformer-markdown/package.json
+++ b/packages/transformer-markdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/transformer-markdown",
-  "version": "1.0.0-alpha.8",
-  "description": "Convert .md files to in-memory JSON model",
+  "version": "1.0.0",
+  "description": "Flatbread transformer plugin that parses Markdown frontmatter and body into content records.",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "dev": "tsup --watch src"
   },
   "engines": {
-    "node": "^14.13.1 || >=16.0.0"
+    "node": ">=20.19"
   },
   "dependencies": {
     "@sindresorhus/slugify": "^2.2.1",

--- a/packages/transformer-yaml/package.json
+++ b/packages/transformer-yaml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/transformer-yaml",
-  "version": "1.0.0-alpha.8",
-  "description": "Convert YAML files to an in-memory JSON model",
+  "version": "1.0.0",
+  "description": "Flatbread transformer plugin that parses YAML files into content records.",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "dev": "tsup --watch src"
   },
   "engines": {
-    "node": "^14.13.1 || >=16.0.0"
+    "node": ">=20.19"
   },
   "dependencies": {
     "@sindresorhus/slugify": "^2.2.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/utils",
-  "version": "1.0.0-alpha.2",
-  "description": "Shared utilities for Flatbread packages",
+  "version": "1.0.0",
+  "description": "Shared helpers for Flatbread packages, including package manager and lockfile detection.",
   "type": "module",
   "scripts": {
     "build": "tsup",
@@ -29,6 +29,9 @@
     "dist",
     "*.d.ts"
   ],
+  "engines": {
+    "node": ">=20.19"
+  },
   "dependencies": {
     "find-up": "^6.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,7 @@ importers:
         version: 9.6.1
       autoprefixer:
         specifier: ^10.4.21
-        version: 10.4.21(postcss@8.5.6)
+        version: 10.4.21(postcss@8.5.14)
       eslint:
         specifier: ^9.33.0
         version: 9.33.0(jiti@2.5.1)
@@ -216,10 +216,10 @@ importers:
   packages/codegen:
     dependencies:
       '@flatbread/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../config
       '@flatbread/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@flatbread/utils':
         specifier: workspace:*
@@ -273,13 +273,13 @@ importers:
 
   packages/config:
     dependencies:
+      '@flatbread/core':
+        specifier: workspace:*
+        version: link:../core
       esbuild:
         specifier: 0.15.1
         version: 0.15.1
     devDependencies:
-      '@flatbread/core':
-        specifier: workspace:*
-        version: link:../core
       '@types/node':
         specifier: 16.11.47
         version: 16.11.47
@@ -326,6 +326,9 @@ importers:
 
   packages/effort-graph:
     dependencies:
+      '@flatbread/core':
+        specifier: workspace:*
+        version: link:../core
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -333,9 +336,6 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
-      '@flatbread/core':
-        specifier: workspace:*
-        version: link:../core
       '@flatbread/transformer-markdown':
         specifier: workspace:*
         version: link:../transformer-markdown
@@ -2352,78 +2352,92 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -2584,24 +2598,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.4.4':
     resolution: {integrity: sha512-LsGUCTvuZ0690fFWerA4lnQvjkYg9gHo12A3wiPUR4kCxbx/d+SlwmonuTH2SWZI+RVGA9VL3N0S03WTYv6bYg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.4.4':
     resolution: {integrity: sha512-aOy5yNRpLL3wNiJVkFYl6w22hdREERNjvegE6vvtix8LHRdsTHhWTpgvcYdCK7AIDCQW5ATmzr9XkPHvSoAnvg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.4.4':
     resolution: {integrity: sha512-FL7OAn4UkR8hKQRGBmlHiHinzOb07tsfARdGh7v0Z0jEJ3sz8/7L5bR23ble9E6DZMabSStqlATHlSxv1fuzAg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.4.4':
     resolution: {integrity: sha512-eEdNW/TXwjYhOulQh0pffTMMItWVwKCQpbziSBmgBNFZIIRn2GTXrhrewevs8wP8KXWYMx8Z+mNU0X+AfvtrRg==}
@@ -2702,36 +2720,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -2875,36 +2899,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
@@ -2981,56 +3011,67 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -3136,24 +3177,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.3':
     resolution: {integrity: sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.3':
     resolution: {integrity: sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.3':
     resolution: {integrity: sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.3':
     resolution: {integrity: sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==}
@@ -3229,24 +3274,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -3650,41 +3699,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -6805,48 +6862,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -13302,14 +13367,14 @@ snapshots:
 
   auto-bind@4.0.0: {}
 
-  autoprefixer@10.4.21(postcss@8.5.6):
+  autoprefixer@10.4.21(postcss@8.5.14):
     dependencies:
       browserslist: 4.25.2
       caniuse-lite: 1.0.30001733
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   ava@4.3.1(@ava/typescript@3.0.1):


### PR DESCRIPTION
Move all public packages to 1.0.0, align package metadata, and add the release license.\n\nLead the public docs with Effort Graph agent memory while keeping static relational content and GraphQL read paths clear. Add concise release notes and record the positioning decision in the Effort Graph.\n\nTest plan: pnpm verify; package tarball and clean-install smoke tests.


Co-authored-by: Cursor <cursoragent@cursor.com>