### PR TITLE
docs(proof): journal paging-only has_more as the product rule

### DIFF
--- a/.flatbread-proof/citations/cit-pr-254-journal-quality-review-22-aug--bf2s44nw13221za3.md
+++ b/.flatbread-proof/citations/cit-pr-254-journal-quality-review-22-aug--bf2s44nw13221za3.md
@@ -1,0 +1,9 @@
+---
+id: cit-pr-254-journal-quality-review-22-aug--bf2s44nw13221za3
+effort: eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+title: PR 254 journal-quality review 22 Aug
+role: evidence
+created_at: '2026-08-22T17:40:41.756Z'
+---
+
+https://github.com/FlatbreadLabs/flatbread/pull/254#pullrequestreview-5000641420

--- a/.flatbread-proof/decisions/dec-address-pr-254-review-as-five-disjoint-file-grou--bx44enbv52ztnrnn.md
+++ b/.flatbread-proof/decisions/dec-address-pr-254-review-as-five-disjoint-file-grou--bx44enbv52ztnrnn.md
@@ -2,10 +2,12 @@
 id: dec-address-pr-254-review-as-five-disjoint-file-grou--bx44enbv52ztnrnn
 effort: eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
 title: Address PR 254 review as five disjoint file groups
-state: accepted
+state: superseded
 created_at: '2026-08-22T16:46:40.750Z'
 derives_from:
   - fnd-pr-254-still-omitted-paging-only-has-more-map-an--hk8r9xfee39s64vc
+superseded_by:
+  - dec-treat-page-has-more-as-pagination-only--dv24ta688adf262v
 ---
 
 Context: PR 254 already exposes complete and cap_reasons. The 22 Aug review asked to document that page.has_more is pagination-only and to lock two missing tests, plus optional refuse of hasMore without a cursor.

--- a/.flatbread-proof/decisions/dec-treat-page-has-more-as-pagination-only--dv24ta688adf262v.md
+++ b/.flatbread-proof/decisions/dec-treat-page-has-more-as-pagination-only--dv24ta688adf262v.md
@@ -1,0 +1,24 @@
+---
+id: dec-treat-page-has-more-as-pagination-only--dv24ta688adf262v
+effort: eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+title: Treat page.has_more as pagination-only
+state: accepted
+created_at: '2026-08-22T17:41:04.977Z'
+derives_from:
+  - fnd-pr-254-completeness-review-asked-for-a-paging-on--r631nr0gnqp9sypt
+  - iss-pr-254-journal-used-issue-kind-on-a-finding-and--9p7t7amz79y5rn3b
+supersedes:
+  - dec-address-pr-254-review-as-five-disjoint-file-grou--bx44enbv52ztnrnn
+---
+
+Supersedes the prior Decision that named five file owners as the Choice. The file split is how the follow-up was split for review, not the rule that shipped.
+
+Context: PR 254 already exposes complete and cap_reasons. The 22 Aug review asked to document that page.has_more is pagination-only, lock two missing tests, and optionally refuse hasMore without a cursor.
+
+Choice: page.has_more means pagination only. Unpaired hasMore without a nextCursor is refused. Hard caps stay on complete and cap_reasons. Callers page only when page.has_more is true. They use cap_reasons and complete for walls.
+
+Note: the follow-up locked that rule in five file groups: CHANGELOG, both reference.md copies, the CLI spawn, the digest unit, and renderDigest. That split is a working note, not the Choice.
+
+Alternatives: keep the file-split Decision as the accepted record; skip the unpaired-cursor refuse. We kept the refuse because docs already call a null cursor an error.
+
+Reversal: revert the follow-up. Digest cache rebuilds on the next read.

--- a/.flatbread-proof/findings/fnd-pr-254-completeness-review-asked-for-a-paging-on--r631nr0gnqp9sypt.md
+++ b/.flatbread-proof/findings/fnd-pr-254-completeness-review-asked-for-a-paging-on--r631nr0gnqp9sypt.md
@@ -1,0 +1,24 @@
+---
+id: fnd-pr-254-completeness-review-asked-for-a-paging-on--r631nr0gnqp9sypt
+effort: eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+title: PR 254 completeness review asked for a paging-only has_more map and two tests
+kind: retrospective
+created_at: '2026-08-22T17:40:57.335Z'
+derives_from:
+  - eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+supersedes:
+  - fnd-pr-254-still-omitted-paging-only-has-more-map-an--hk8r9xfee39s64vc
+cites:
+  - cit-pr-254-grouped-review-22-aug--cpbe5anhpby3h625
+  - cit-pr-254-journal-quality-review-22-aug--bf2s44nw13221za3
+---
+
+Supersedes the prior Finding that used Issue kind gap. The 22 Aug grouping review of PR 254 listed four open 19 Aug notes and one optional harden. Those were docs and test locks, recorded here as a retrospective.
+
+1. CHANGELOG advertised complete and cap_reasons but not that page.has_more is pagination-only.
+2. Both reference.md copies still said narrow or page when a hard cap hit. Paging cannot clear displayed_edges.
+3. The CLI page-only spawn checked has_more but not next_cursor, and skipped a null cursor on bytes plus summary co-list on relations.
+4. Digest unit cases never set hasMore with a hard cap, so summary pagination plus a hard reason was unproven.
+5. Optional: renderDigest could still emit has_more true with a null cursor if DigestInput was mis-paired.
+
+None of these said the feature was wrong. They asked to say the Load more rule out loud and lock it. The follow-up commit did that. A later review asked to journal the product rule, not the file split, and to stop using Issue kind on this Finding.

--- a/.flatbread-proof/findings/fnd-pr-254-still-omitted-paging-only-has-more-map-an--hk8r9xfee39s64vc.md
+++ b/.flatbread-proof/findings/fnd-pr-254-still-omitted-paging-only-has-more-map-an--hk8r9xfee39s64vc.md
@@ -6,6 +6,8 @@ kind: gap
 created_at: '2026-08-22T16:46:30.481Z'
 derives_from:
   - eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+superseded_by:
+  - fnd-pr-254-completeness-review-asked-for-a-paging-on--r631nr0gnqp9sypt
 cites:
   - cit-pr-254-grouped-review-22-aug--cpbe5anhpby3h625
 ---

--- a/.flatbread-proof/issues/iss-pr-254-journal-used-issue-kind-on-a-finding-and--9p7t7amz79y5rn3b.md
+++ b/.flatbread-proof/issues/iss-pr-254-journal-used-issue-kind-on-a-finding-and--9p7t7amz79y5rn3b.md
@@ -1,0 +1,19 @@
+---
+id: iss-pr-254-journal-used-issue-kind-on-a-finding-and--9p7t7amz79y5rn3b
+effort: eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+title: PR 254 journal used Issue kind on a Finding and titled the file split
+kind: gap
+status: resolved
+created_at: '2026-08-22T17:40:48.881Z'
+derives_from:
+  - eff-proof-and-contributor-operating-system--ahhgtafvdhg4dfve
+resolved_by:
+  - dec-treat-page-has-more-as-pagination-only--dv24ta688adf262v
+cites:
+  - cit-pr-254-journal-quality-review-22-aug--bf2s44nw13221za3
+---
+
+The 22 Aug PR review of the completeness follow-up found two journal errors, not envelope bugs.
+
+1. Finding fnd-pr-254-still-omitted-paging-only-has-more-map-an--hk8r9xfee39s64vc used kind gap. That kind belongs on WriteIssue. A Finding should use measurement, retrospective, or a review label.
+2. Accepted Decision dec-address-pr-254-review-as-five-disjoint-file-grou--bx44enbv52ztnrnn titled the Choice as five file owners. The product rule is: page.has_more is pagination-only; unpaired hasMore is refused; hard caps stay on complete and cap_reasons.


### PR DESCRIPTION
## Summary

Addresses the two open 22 Aug journal-quality notes on #254. No envelope code changed.

1. The Finding that used Issue kind `gap` is superseded by a `retrospective` Finding. The gap itself is now Issue `iss-pr-254-journal-used-issue-kind-on-a-finding-and--9p7t7amz79y5rn3b`.
2. Accepted Decision `dec-treat-page-has-more-as-pagination-only--dv24ta688adf262v` states the product rule as the Choice (`page.has_more` is pagination-only; unpaired `hasMore` is refused; hard caps stay on `complete` / `cap_reasons`). The five-file split is a note. Accepted with `rejectSiblings: false`. The prior file-split Decision is `superseded`.

Related #254.

## Test plan

- [x] Proof CLI mutations only (no hand-edited frontmatter)
- [x] Other proposed Decisions in the Effort remain `proposed`
- [x] Prettier on the new records


Made with [Cursor](https://cursor.com)