### PR TITLE
docs: use Proof as the product name, not The Proof

### DIFF
--- a/.agents/skills/effort-modeling/SKILL.md
+++ b/.agents/skills/effort-modeling/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: effort-modeling
-description: Sharpen a project's vocabulary and planning through one-question-at-a-time grilling, then journal Decisions, Constraints, Findings, Issues, and Risks into the Flatbread Proof. Use when a plan needs durable reasoning instead of ADRs.
+description: Sharpen a project's vocabulary and planning through one-question-at-a-time grilling, then journal Decisions, Constraints, Findings, Issues, and Risks into Proof. Use when a plan needs durable reasoning instead of ADRs.
 disable-model-invocation: true
 ---
 
 # Effort modeling
 
 Use this discipline while a plan or design is being shaped. Store planning
-records in the Proof. Keep project terms in a glossary such as
+records in Proof. Keep project terms in a glossary such as
 `CONTEXT.md` or `docs/glossary.md`.
 
 ## Resume before asking
@@ -36,7 +36,7 @@ answer, and resolve prerequisite choices before dependent ones.
 ## Journal the right speech act
 
 Use `flatbread proof write` for the current Effort, following
-[the Proof reference](../proof/reference.md):
+[Proof reference](../proof/reference.md):
 
 - **Finding** — evidence about code, users, or runtime behavior.
 - **Issue** — a question, defect, gap, or blocker needing attention.

--- a/.agents/skills/grill-with-efforts/SKILL.md
+++ b/.agents/skills/grill-with-efforts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill-with-efforts
-description: Run a relentless one-question-at-a-time planning interview that sharpens vocabulary and journals durable reasoning into the Flatbread Proof. Use when a plan is fuzzy and needs an Proof trail instead of ADRs.
+description: Run a relentless one-question-at-a-time planning interview that sharpens vocabulary and journals durable reasoning into Proof. Use when a plan is fuzzy and needs a Proof trail instead of ADRs.
 disable-model-invocation: true
 ---
 

--- a/.agents/skills/proof/SKILL.md
+++ b/.agents/skills/proof/SKILL.md
@@ -5,7 +5,7 @@ description: Journal reasoning (decisions, findings, issues, constraints, risks,
 
 # Proof — agent journaling and recall
 
-The Proof stores durable project memory as markdown records in the
+Proof stores durable project memory as markdown records in the
 repository. It has eight record types: **Effort**, **Issue**, **Finding**,
 **Decision**, **Constraint**, and **Risk** capture the work and reasoning;
 **Citation** stores a source or reference; and **Blob** stores attached

--- a/.agents/skills/proof/glossary.md
+++ b/.agents/skills/proof/glossary.md
@@ -1,6 +1,6 @@
 # Proof glossary
 
-The Proof is persistent, queryable memory for long-horizon software
+Proof is persistent, queryable memory for long-horizon software
 work. It builds on Flatbread's content vocabulary: each primitive is a
 Collection, its instances are Records, and cross-primitive references are
 Relations in frontmatter.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -16,7 +16,7 @@ control how it reads files and turns them into data.
 
 ## The lead use case: memory for coding agents
 
-The [Proof](../packages/proof/README.md) is a Flatbread content
+[Proof](../packages/proof/README.md) is a Flatbread content
 model for what a coding agent works out along the way. An agent records an
 Effort and then writes Issues, Findings, Decisions, Constraints, Risks,
 Citations, and Blobs against it. Each record is a markdown file under

--- a/packages/explorer/README.md
+++ b/packages/explorer/README.md
@@ -1,7 +1,7 @@
 # `@flatbread/explorer`
 
 Content-relation explorer for Flatbread. v1 ships a generic single-page app
-(SPA) shell plus an **Proof** preset. When your config uses
+(SPA) shell plus a **Proof** preset. When your config uses
 `proofContent()`, `flatbread start` serves this UI at `/`.
 
 ## Try it locally

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatbread/explorer",
   "version": "1.0.1",
-  "description": "Single-page app for browsing a Flatbread content graph, served by flatbread start. Ships an Proof preset.",
+  "description": "Single-page app for browsing a Flatbread content graph, served by flatbread start. Ships a Proof preset.",
   "type": "module",
   "scripts": {
     "build": "pnpm build:node && pnpm build:web",

--- a/packages/explorer/src/web/app/components/ProofApp.tsx
+++ b/packages/explorer/src/web/app/components/ProofApp.tsx
@@ -127,7 +127,7 @@ function EmptyState({
         ]
       : [
           'No Proof records yet',
-          'Nothing found in the Proof content root. Journal a record and it will grow in here.',
+          'Nothing found in this content root. Journal a record and it will grow in here.',
         ];
 
   return (

--- a/packages/flatbread/README.md
+++ b/packages/flatbread/README.md
@@ -23,7 +23,7 @@ CLI.
 
 People use it two ways.
 
-**Durable memory for coding agents.** The
+**Durable memory for coding agents.**
 [Proof](https://github.com/FlatbreadLabs/flatbread/tree/main/packages/proof)
 stores an agent's reasoning as markdown records in the repository: Efforts,
 Issues, Findings, Decisions, Constraints, Risks, Citations, and Blobs. An agent

--- a/packages/flatbread/src/cli/proof.test.ts
+++ b/packages/flatbread/src/cli/proof.test.ts
@@ -1063,6 +1063,30 @@ export default {
 );
 
 test.serial(
+  'bootstrap names the write journal for Proof without a branded The Proof',
+  async (t) => {
+    const cwd = await createTempProject('flatbread-bootstrap-journal-copy-', t);
+    await writeFile(
+      join(cwd, 'flatbread.config.js'),
+      `import { source } from '@flatbread/source-filesystem';
+import { transformer } from '@flatbread/transformer-markdown';
+import { proofContent } from '@flatbread/proof';
+export default { source: source(), transformer: transformer(), content: proofContent() };`
+    );
+    const report = await inspectEffortBootstrap(cwd);
+    const journal = report.requirements.find(
+      (requirement) =>
+        requirement.code === 'EFFORT_BOOTSTRAP_JOURNAL_IGNORE_MISSING'
+    );
+    t.is(
+      journal?.message,
+      'The write journal for Proof at .flatbread-proof is not ignored.'
+    );
+    t.false((journal?.message ?? '').includes('The Proof'));
+  }
+);
+
+test.serial(
   'bootstrap detects a ready custom root and verify returns action-required JSON state',
   async (t) => {
     const cwd = await createTempProject('flatbread-bootstrap-ready-', t);

--- a/packages/flatbread/src/cli/proof.ts
+++ b/packages/flatbread/src/cli/proof.ts
@@ -325,7 +325,7 @@ export async function inspectEffortBootstrap(
     requirements.push(
       requirement(
         'EFFORT_BOOTSTRAP_JOURNAL_IGNORE_MISSING',
-        `The Proof journal for ${graphRoot} is not ignored.`,
+        `The write journal for Proof at ${graphRoot} is not ignored.`,
         `Add **/${graphRoot}/.journal/ to .gitignore.`
       )
     );

--- a/packages/proof/skills/effort-modeling/SKILL.md
+++ b/packages/proof/skills/effort-modeling/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: effort-modeling
-description: Sharpen a project's vocabulary and planning through one-question-at-a-time grilling, then journal Decisions, Constraints, Findings, Issues, and Risks into the Flatbread Proof. Use when a plan needs durable reasoning instead of ADRs.
+description: Sharpen a project's vocabulary and planning through one-question-at-a-time grilling, then journal Decisions, Constraints, Findings, Issues, and Risks into Proof. Use when a plan needs durable reasoning instead of ADRs.
 disable-model-invocation: true
 ---
 
 # Effort modeling
 
 Use this discipline while a plan or design is being shaped. Store planning
-records in the Proof. Keep project terms in a glossary such as
+records in Proof. Keep project terms in a glossary such as
 `CONTEXT.md` or `docs/glossary.md`.
 
 ## Resume before asking
@@ -36,7 +36,7 @@ answer, and resolve prerequisite choices before dependent ones.
 ## Journal the right speech act
 
 Use `flatbread proof write` for the current Effort, following
-[the Proof reference](../proof/reference.md):
+[Proof reference](../proof/reference.md):
 
 - **Finding** — evidence about code, users, or runtime behavior.
 - **Issue** — a question, defect, gap, or blocker needing attention.

--- a/packages/proof/skills/grill-with-efforts/SKILL.md
+++ b/packages/proof/skills/grill-with-efforts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill-with-efforts
-description: Run a relentless one-question-at-a-time planning interview that sharpens vocabulary and journals durable reasoning into the Flatbread Proof. Use when a plan is fuzzy and needs an Proof trail instead of ADRs.
+description: Run a relentless one-question-at-a-time planning interview that sharpens vocabulary and journals durable reasoning into Proof. Use when a plan is fuzzy and needs a Proof trail instead of ADRs.
 disable-model-invocation: true
 ---
 

--- a/packages/proof/skills/proof/SKILL.md
+++ b/packages/proof/skills/proof/SKILL.md
@@ -5,7 +5,7 @@ description: Journal reasoning (decisions, findings, issues, constraints, risks,
 
 # Proof — agent journaling and recall
 
-The Proof stores durable project memory as markdown records in the
+Proof stores durable project memory as markdown records in the
 repository. It has eight record types: **Effort**, **Issue**, **Finding**,
 **Decision**, **Constraint**, and **Risk** capture the work and reasoning;
 **Citation** stores a source or reference; and **Blob** stores attached

--- a/packages/proof/skills/proof/glossary.md
+++ b/packages/proof/skills/proof/glossary.md
@@ -1,6 +1,6 @@
 # Proof glossary
 
-The Proof is persistent, queryable memory for long-horizon software
+Proof is persistent, queryable memory for long-horizon software
 work. It builds on Flatbread's content vocabulary: each primitive is a
 Collection, its instances are Records, and cross-primitive references are
 Relations in frontmatter.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary of changes**

Proof is the product name. A leading "The" is not part of the brand. This drop it from user-facing copy that treated the product as "The Proof".

- README and positioning: sentences now start with Proof, not "The Proof"
- Packaged Proof skills (and the generated `.agents/` copies): same fix, plus "in Proof" instead of "in the Proof"
- Bootstrap CLI: journal ignore message is now "The write journal for Proof at …"
- Explorer empty state no longer says "the Proof content root"
- Related article errors: "an Proof" → "a Proof" in explorer package copy

Phrases such as "the Proof skill" stay. There the article belongs to the noun after Proof.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] I added doc comments to any new public exports, and inline comments to any hard-to-understand areas
- [x] My changes generate no new console errors locally
- [x] If applicable, try to include a test that fails without this PR but passes with it

### Does this introduce any non-backwards compatible changes?

- [ ] Yes
- [x] No

The bootstrap journal-ignore string changed. That is operator-facing copy, not a config or API break.

### Does this include any user config changes?

- [ ] Yes
- [x] No

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d109463-4bf5-44ac-99ab-fee607788008?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d109463-4bf5-44ac-99ab-fee607788008&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

