### PR TITLE
release: bump public packages to 1.1.0

### DIFF
--- a/.agents/skills/proof/release.json
+++ b/.agents/skills/proof/release.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "flatbreadVersion": "1.0.1",
-  "proofVersion": "1.0.1",
-  "gitTag": "v1.0.1"
+  "flatbreadVersion": "1.1.0",
+  "proofVersion": "1.1.0",
+  "gitTag": "v1.1.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,52 @@
 
 ## Unreleased
 
-- `flatbread proof write` now accepts `Retract`. Session noise and other
-  records that should not stay on the live graph are tombstoned in place:
-  the file remains, browse reads omit it, and the writer strips the id from
-  other records in the same Effort so relation reads do not fail closed.
-  `proof get` still returns the retracted record. Efforts cannot be
+Notes for the Flatbread release train. Some packages also keep their own
+changelog; this file covers the repository as a whole.
+
+## 1.1.0
+
+- `flatbread proof write` now accepts `Retract` (#260). Session noise and
+  other records that should not stay on the live graph are tombstoned in
+  place: the file remains, browse reads omit it, and the writer strips the
+  id from other records in the same Effort so relation reads do not fail
+  closed. `proof get` still returns the retracted record. Efforts cannot be
   retracted; abandon them instead. Do not `git rm` Proof records.
+  Retract refuses a sole closer (the last live record that closes another
+  live record in the same Effort) and refuses the last live Finding on a
+  realized Risk.
 - The Proof skill now applies a 4/4 write gate. Agents score the information
   before a create or a body edit that adds claims; existing records do not
   bypass the gate. Four bundled eval cases ship with the skill for a manual
   eval run.
-- Proof read envelopes now expose `complete` and `cap_reasons`. `page.has_more`
-  is pagination-only and no longer signals the 25-record wall; use
-  `cap_reasons` / `complete` for hard caps on `displayed_edges` and `bytes`.
-  The `primary_records` limit remains an in-process defensive signal because
-  the CLI read bridge slices to 25 records before rendering. Callers can tell
-  paging from hard caps without parsing the digest Markdown or `summary` text.
+- Proof read envelopes now expose `complete` and `cap_reasons` (#254).
+  `page.has_more` is pagination-only and no longer signals the 25-record
+  wall; use `cap_reasons` / `complete` for hard caps on `displayed_edges`
+  and `bytes`. The `primary_records` limit remains an in-process defensive
+  signal because the CLI read bridge slices to 25 records before rendering.
+  An unpaired `hasMore` flag without a non-empty cursor is refused. Callers
+  can tell paging from hard caps without parsing the digest Markdown or
+  `summary` text.
 - **Breaking for writes:** Proof now rejects create-time `derives_from`,
-  `supersedes`, and `invalidates` targets from another Effort. The later
-  `Supersede` and `Invalidate` forms already rejected these edges. Rejected
-  creates write no record or reverse projection and leave the generation
-  unchanged.
-  `flatbread proof relations` now reports stored legacy or hand-edited foreign
-  edges as `PROOF_CROSS_EFFORT_RELATION` instead of dropping them into a
-  successful empty page.
-
-Notes for the Flatbread release train. Some packages also keep their own
-changelog; this file covers the repository as a whole.
+  `supersedes`, and `invalidates` targets from another Effort (#253). The
+  later `Supersede` and `Invalidate` forms already rejected these edges.
+  Rejected creates write no record or reverse projection and leave the
+  generation unchanged.
+  `flatbread proof relations` now reports stored legacy or hand-edited
+  foreign edges as `PROOF_CROSS_EFFORT_RELATION` instead of dropping them
+  into a successful empty page.
+- READMEs and docs use Proof as the product name, not "The Proof" (#259).
+- Brand marks land under `assets/brand/` for docs and GitHub releases
+  (#256).
+- `pnpm publish:ci` now creates the GitHub release from the filed
+  `CHANGELOG.md` section after every public package is on npm (#261).
+  `pnpm publish:dry` runs the same readiness gates without writing.
 
 ## 1.0.1
 
+- All public packages ship at lockstep `1.0.1`.
+- `pnpm publish:ci` treats an npm registry 404 as "not yet published" and
+  continues, instead of aborting the remaining packages.
 - The DAG runner is now `@flatbread/oven` (`pnpm exec oven`); the memory package is now `@flatbread/proof` with the `flatbread proof` CLI.
 - `@flatbread/source-filesystem` reads a content directory that does not exist
   as an empty collection instead of throwing `ENOENT`. Git cannot store an

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/codegen",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Generates TypeScript types, typed document nodes, and a prototype read API from a Flatbread content model.",
   "type": "module",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/config",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Loads, validates, and types flatbread.config.* files. Provides defineConfig().",
   "type": "module",
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Flatbread's engine: runs source and transformer plugins, validates records and refs, and builds the GraphQL schema plus JSON and CSV snapshots.",
   "type": "module",
   "scripts": {

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/explorer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Single-page app for browsing a Flatbread content graph, served by flatbread start. Ships a Proof preset.",
   "type": "module",
   "scripts": {

--- a/packages/flatbread/package.json
+++ b/packages/flatbread/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbread",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Git-native memory for coding agents and relational content for TypeScript apps. Files in your repo become a typed graph you read over GraphQL, generated TypeScript, or the CLI.",
   "type": "module",
   "scripts": {

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/proof",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Git-native memory records for coding agents. Writes typed Effort, Issue, Finding, Decision, Constraint, Risk, Citation, and Blob records to Markdown as journaled changes, and reads them back in bounded pages.",
   "type": "module",
   "scripts": {

--- a/packages/proof/skills/proof/release.json
+++ b/packages/proof/skills/proof/release.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "flatbreadVersion": "1.0.1",
-  "proofVersion": "1.0.1",
-  "gitTag": "v1.0.1"
+  "flatbreadVersion": "1.1.0",
+  "proofVersion": "1.1.0",
+  "gitTag": "v1.1.0"
 }

--- a/packages/resolver-svimg/package.json
+++ b/packages/resolver-svimg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/resolver-svimg",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Flatbread field resolver that turns an image path into svimg attributes: responsive srcsets, WebP and AVIF variants, and a blurred placeholder.",
   "type": "module",
   "repository": {

--- a/packages/source-filesystem/package.json
+++ b/packages/source-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/source-filesystem",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Flatbread source plugin that reads content files from directories on disk.",
   "type": "module",
   "repository": {

--- a/packages/transformer-markdown/package.json
+++ b/packages/transformer-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/transformer-markdown",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Flatbread transformer plugin that parses Markdown frontmatter and body into content records.",
   "type": "module",
   "repository": {

--- a/packages/transformer-yaml/package.json
+++ b/packages/transformer-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/transformer-yaml",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Flatbread transformer plugin that parses YAML files into content records.",
   "type": "module",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/utils",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Shared helpers for Flatbread packages, including package manager and lockfile detection.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Lockstep bump of every public package from 1.0.1 to 1.1.0. Files the 1.1.0 changelog.

npm 1.1.0 and the GitHub release https://github.com/FlatbreadLabs/flatbread/releases/tag/v1.1.0 are already published from `eb74911`. This PR lands that bump on `main`.

## Test plan

- [x] `pnpm publish:dry` passed on `eb74911`
- [x] All public packages are `1.1.0` on npm (`latest`)
- [x] GitHub release `v1.1.0` is published and marked Latest


Made with [Cursor](https://cursor.com)