### PR TITLE
release: bump public packages to 1.2.0

### DIFF
--- a/.agents/skills/proof/release.json
+++ b/.agents/skills/proof/release.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "flatbreadVersion": "1.1.0",
-  "proofVersion": "1.1.0",
-  "gitTag": "v1.1.0"
+  "flatbreadVersion": "1.2.0",
+  "proofVersion": "1.2.0",
+  "gitTag": "v1.2.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## 1.2.0
+
 - `flatbread proof install-skill` installs the Proof skill that shipped with
-  the running CLI and pins that same `flatbread` version as a devDependency.
-  End-user docs now tell people to run
+  the running CLI and pins that same `flatbread` version as a devDependency
+  (#267). End-user docs now tell people to run
   `npx --yes flatbread@latest proof install-skill`, so README copy-paste
   blocks no longer need a version or git tag on every release.
 

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/codegen",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Generates TypeScript types, typed document nodes, and a prototype read API from a Flatbread content model.",
   "type": "module",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Loads, validates, and types flatbread.config.* files. Provides defineConfig().",
   "type": "module",
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flatbread's engine: runs source and transformer plugins, validates records and refs, and builds the GraphQL schema plus JSON and CSV snapshots.",
   "type": "module",
   "scripts": {

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/explorer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Single-page app for browsing a Flatbread content graph, served by flatbread start. Ships a Proof preset.",
   "type": "module",
   "scripts": {

--- a/packages/flatbread/package.json
+++ b/packages/flatbread/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbread",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Git-native memory for coding agents and relational content for TypeScript apps. Files in your repo become a typed graph you read over GraphQL, generated TypeScript, or the CLI.",
   "type": "module",
   "scripts": {

--- a/packages/proof/package.json
+++ b/packages/proof/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/proof",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Git-native memory records for coding agents. Writes typed Effort, Issue, Finding, Decision, Constraint, Risk, Citation, and Blob records to Markdown as journaled changes, and reads them back in bounded pages.",
   "type": "module",
   "scripts": {

--- a/packages/proof/skills/proof/release.json
+++ b/packages/proof/skills/proof/release.json
@@ -1,6 +1,6 @@
 {
   "format": 1,
-  "flatbreadVersion": "1.1.0",
-  "proofVersion": "1.1.0",
-  "gitTag": "v1.1.0"
+  "flatbreadVersion": "1.2.0",
+  "proofVersion": "1.2.0",
+  "gitTag": "v1.2.0"
 }

--- a/packages/resolver-svimg/package.json
+++ b/packages/resolver-svimg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/resolver-svimg",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flatbread field resolver that turns an image path into svimg attributes: responsive srcsets, WebP and AVIF variants, and a blurred placeholder.",
   "type": "module",
   "repository": {

--- a/packages/source-filesystem/package.json
+++ b/packages/source-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/source-filesystem",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flatbread source plugin that reads content files from directories on disk.",
   "type": "module",
   "repository": {

--- a/packages/transformer-markdown/package.json
+++ b/packages/transformer-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/transformer-markdown",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flatbread transformer plugin that parses Markdown frontmatter and body into content records.",
   "type": "module",
   "repository": {

--- a/packages/transformer-yaml/package.json
+++ b/packages/transformer-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/transformer-yaml",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flatbread transformer plugin that parses YAML files into content records.",
   "type": "module",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatbread/utils",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shared helpers for Flatbread packages, including package manager and lockfile detection.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Lockstep bump of every public package from 1.1.0 to 1.2.0. Files the
1.2.0 changelog from Unreleased.

After this commit is on GitHub, `pnpm publish:ci` publishes the npm
packages, tags `v1.2.0`, and opens the GitHub release from the filed
CHANGELOG.md section.

## 1.2.0

- `flatbread proof install-skill` installs the Proof skill that shipped
  with the running CLI and pins that same `flatbread` version as a
  devDependency (#267). End-user docs now tell people to run
  `npx --yes flatbread@latest proof install-skill`, so README copy-paste
  blocks no longer need a version or git tag on every release.

## Checklist

- [x] New public CLI: `flatbread proof install-skill`
- [x] Changes generate no new console errors
- [x] Version and changelog only; no new tests required

### Does this introduce any non-backwards compatible changes?

- [ ] Yes
- [x] No

### Does this include any user config changes?

- [ ] Yes
- [x] No

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release metadata; no application logic changes in the diff.
> 
> **Overview**
> **Lockstep release prep** for **1.2.0**: every listed public `package.json` moves **1.1.0 → 1.2.0**, and both Proof skill **`release.json`** files (`.agents/skills/proof/` and `packages/proof/skills/proof/`) update **`flatbreadVersion`**, **`proofVersion`**, and **`gitTag`** to match.
> 
> **CHANGELOG** gains a filed **`## 1.2.0`** section (moved off **Unreleased**) documenting **`flatbread proof install-skill`** (#267): installs the skill from the running CLI, pins that **`flatbread`** version as a devDependency, and docs standardize on **`npx --yes flatbread@latest proof install-skill`**. No runtime or API code changes in this diff—publish/tag follows via **`pnpm publish:ci`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e576204cf2b7699704afe971b14d05c978df32c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->